### PR TITLE
Add starting_page and finished columns to books table

### DIFF
--- a/migrations/0001_acoustic_black_crow.sql
+++ b/migrations/0001_acoustic_black_crow.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `books` ADD `starting_page` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `books` ADD `finished` integer DEFAULT false NOT NULL;

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,208 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "edfe050f-c322-4508-aa9c-d6498a584793",
+  "prevId": "cc6c8d16-a1ca-4869-a382-29ec980fd586",
+  "tables": {
+    "books": {
+      "name": "books",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_sex": {
+          "name": "author_sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recommended": {
+          "name": "recommended",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_acquired": {
+          "name": "date_acquired",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_removed": {
+          "name": "date_removed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starting_page": {
+          "name": "starting_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finished": {
+          "name": "finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reading_sessions": {
+      "name": "reading_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_read": {
+          "name": "pages_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished": {
+          "name": "finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reading_sessions_book_id_books_id_fk": {
+          "name": "reading_sessions_book_id_books_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1745588677562,
       "tag": "0000_big_karma",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1745607409799,
+      "tag": "0001_acoustic_black_crow",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -15,6 +15,8 @@ export const books = sqliteTable('books', {
   dateAcquired: text('date_acquired').notNull(), // ISO date string format
   dateRemoved: text('date_removed'),             // ISO date string format, optional
   cost: real('cost').notNull(),
+  startingPage: integer('starting_page').default(0).notNull(),
+  finished: integer('finished', { mode: 'boolean' }).default(false).notNull(),
 });
 
 export const readingSessions = sqliteTable('reading_sessions', {

--- a/src/pages/api/reading-sessions.ts
+++ b/src/pages/api/reading-sessions.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import type { ReadingSession } from '../../lib/schema';
-import { getAllReadingSessions, addReadingSession } from '../../lib/db';
+import { getAllReadingSessions, addReadingSession, updateBook, getBookById } from '../../lib/db';
 
 export const GET: APIRoute = async ({ locals }) => {
   const sessions = await getAllReadingSessions(locals.runtime.env);
@@ -20,6 +20,20 @@ export const POST: APIRoute = async ({ request, locals }) => {
   try {
     const sessionData = await request.json() as Omit<ReadingSession, 'id'>;
     const newSession = await addReadingSession(sessionData, locals.runtime.env);
+
+    // If the session marks the book as finished, update the book's finished status
+    if (sessionData.finished) {
+      // Get the book
+      try {
+        const book = await getBookById(sessionData.bookId, locals.runtime.env);
+        if (book && !book.finished) {
+          // Update the book's finished status
+          await updateBook(sessionData.bookId, { finished: true }, locals.runtime.env);
+        }
+      } catch (error) {
+        console.error('Error updating book finished status:', error);
+      }
+    }
 
     return new Response(
       JSON.stringify(newSession),

--- a/src/pages/api/reading-sessions/[id].ts
+++ b/src/pages/api/reading-sessions/[id].ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import type { ReadingSession } from '../../../lib/schema';
-import { updateReadingSession, deleteReadingSession, getReadingSessionById } from '../../../lib/db';
+import { updateReadingSession, deleteReadingSession, getReadingSessionById, getBookById, updateBook } from '../../../lib/db';
 
 export const GET: APIRoute = async ({ params, locals }) => {
   const { id } = params;
@@ -65,6 +65,20 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
           }
         }
       );
+    }
+
+    // If the session was marked as finished, update the book's finished status
+    if (updates.finished === true) {
+      // Get the book
+      try {
+        const book = await getBookById(updatedSession.bookId, locals.runtime.env);
+        if (book && !book.finished) {
+          // Update the book's finished status
+          await updateBook(updatedSession.bookId, { finished: true }, locals.runtime.env);
+        }
+      } catch (error) {
+        console.error('Error updating book finished status:', error);
+      }
     }
 
     return new Response(

--- a/src/pages/books/[id]/edit.astro
+++ b/src/pages/books/[id]/edit.astro
@@ -13,7 +13,7 @@ if (!book) {
   return Astro.redirect('/books');
 }
 
-const formatOptions = ['Paperback', 'Hardcover', 'E-book', 'Audiobook'];
+const formatOptions = ['Physical', 'E-book', 'Audiobook'];
 // const genres = [
 //   'Fiction',
 //   'Non-fiction',
@@ -117,6 +117,18 @@ const formatOptions = ['Paperback', 'Hardcover', 'E-book', 'Audiobook'];
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
+          <label for="genre" class="form-label">Genre</label>
+          <input
+            type="text"
+            id="genre"
+            name="genre"
+            class="form-input"
+            value={book.genre}
+            required
+          />
+        </div>
+
+        <div>
           <label class="form-label mb-2">Recommended to me</label>
           <div class="flex items-center space-x-4">
             <label class="inline-flex items-center">
@@ -140,18 +152,6 @@ const formatOptions = ['Paperback', 'Hardcover', 'E-book', 'Audiobook'];
               <span class="ml-2">No</span>
             </label>
           </div>
-        </div>
-
-        <div>
-          <label for="genre" class="form-label">Genre</label>
-          <input
-            type="text"
-            id="genre"
-            name="genre"
-            class="form-input"
-            value={book.genre}
-            required
-          />
         </div>
       </div>
 
@@ -209,6 +209,46 @@ const formatOptions = ['Paperback', 'Hardcover', 'E-book', 'Audiobook'];
         </div>
       </div>
 
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label for="startingPage" class="form-label">Starting Page</label>
+          <input
+            type="number"
+            id="startingPage"
+            name="startingPage"
+            min="0"
+            class="form-input"
+            value={book.startingPage || 0}
+          />
+        </div>
+
+        <div>
+          <label class="form-label mb-2">Finished</label>
+          <div class="flex items-center space-x-4">
+            <label class="inline-flex items-center">
+              <input
+                type="radio"
+                name="finished"
+                value="true"
+                class="form-radio"
+                checked={book.finished}
+              />
+              <span class="ml-2">Yes</span>
+            </label>
+            <label class="inline-flex items-center">
+              <input
+                type="radio"
+                name="finished"
+                value="false"
+                class="form-radio"
+                checked={!book.finished}
+              />
+              <span class="ml-2">No</span>
+            </label>
+          </div>
+        </div>
+      </div>
+
       <div class="flex justify-between">
         <a href={`/books/${id}`} class="btn-secondary">Cancel</a>
         <button type="submit" class="btn">Save Changes</button>
@@ -244,6 +284,8 @@ const formatOptions = ['Paperback', 'Hardcover', 'E-book', 'Audiobook'];
           dateAcquired: formData.get('dateAcquired') || '',
           dateRemoved: null,
           cost: formData.get('cost') ? parseFloat(formData.get('cost')) : 0,
+          startingPage: parseInt(formData.get('startingPage')) || 0,
+          finished: formData.get('finished') === 'true',
         };
 
         try {

--- a/src/pages/books/[id]/index.astro
+++ b/src/pages/books/[id]/index.astro
@@ -30,6 +30,25 @@ const progress = calculateProgress(book, readingSessions);
 const sortedSessions = [...readingSessions].sort((a, b) => {
   return new Date(b.date).getTime() - new Date(a.date).getTime();
 });
+
+// Format date in UK format (DD/MM/YYYY)
+function formatDate(dateString: string): string {
+  try {
+    // Parse ISO date string
+    const date = new Date(dateString);
+
+    // Check if the date is valid
+    if (!isNaN(date.getTime())) {
+      return date.toLocaleDateString('en-GB');
+    }
+
+    // Return the original if we couldn't parse it
+    return dateString;
+  } catch (e) {
+    // If parsing fails, return the original
+    return dateString;
+  }
+}
 ---
 
 <Layout title={`${book.title} | PageTurn`}>
@@ -145,12 +164,34 @@ const sortedSessions = [...readingSessions].sort((a, b) => {
 
           <div>
             <h3 class="text-sm text-indigo-400 mb-1">Date Acquired</h3>
-            <p>{new Date(book.dateAcquired).toLocaleDateString()}</p>
+            <p>{formatDate(book.dateAcquired)}</p>
           </div>
 
           <div>
             <h3 class="text-sm text-indigo-400 mb-1">Cost</h3>
             <p>${book.cost.toFixed(2)}</p>
+          </div>
+
+          <div>
+            <h3 class="text-sm text-indigo-400 mb-1">Starting Page</h3>
+            <p>{book.startingPage}</p>
+          </div>
+
+          <div>
+            <h3 class="text-sm text-indigo-400 mb-1">Status</h3>
+            <p>
+              {
+                book.finished ? (
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-900/50 text-green-300 border border-green-800">
+                    Finished
+                  </span>
+                ) : (
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-900/50 text-blue-300 border border-blue-800">
+                    In Progress
+                  </span>
+                )
+              }
+            </p>
           </div>
         </div>
       </div>
@@ -199,6 +240,11 @@ const sortedSessions = [...readingSessions].sort((a, b) => {
                 <div class="flex justify-between text-sm mt-1">
                   <span>
                     {progress.pagesRead} / {book.pageCount} pages
+                    {book.startingPage > 0 && (
+                      <span class="text-xs text-indigo-400 ml-1">
+                        (includes {book.startingPage} untracked pages)
+                      </span>
+                    )}
                   </span>
                   <span>{progress.percentComplete.toFixed(1)}%</span>
                 </div>
@@ -275,7 +321,7 @@ const sortedSessions = [...readingSessions].sort((a, b) => {
 
                   return (
                     <tr>
-                      <td>{new Date(session.date).toLocaleDateString()}</td>
+                      <td>{formatDate(session.date)}</td>
                       <td>{session.pagesRead}</td>
                       <td>{session.duration}</td>
                       <td>{pagesPerHour.toFixed(1)}</td>

--- a/src/pages/books/new.astro
+++ b/src/pages/books/new.astro
@@ -18,6 +18,8 @@ let formData = {
   publisher: '',
   dateAcquired: new Date().toISOString().split('T')[0],
   cost: '',
+  startingPage: '0',
+  finished: false,
 };
 
 if (Astro.request.method === 'POST') {
@@ -41,6 +43,8 @@ if (Astro.request.method === 'POST') {
         (data.get('dateAcquired') as string) ||
         new Date().toISOString().split('T')[0],
       cost: (data.get('cost') as string) || '',
+      startingPage: (data.get('startingPage') as string) || '0',
+      finished: data.get('finished') === 'true',
     };
 
     const book = {
@@ -57,6 +61,8 @@ if (Astro.request.method === 'POST') {
       dateAcquired: formData.dateAcquired,
       dateRemoved: null,
       cost: parseFloat(formData.cost) || 0,
+      startingPage: parseInt(formData.startingPage) || 0,
+      finished: formData.finished,
     };
 
     // Validate required fields
@@ -128,11 +134,8 @@ if (Astro.request.method === 'POST') {
             <option value="" selected={formData.format === ''}
               >Select a format</option
             >
-            <option value="Hardcover" selected={formData.format === 'Hardcover'}
-              >Hardcover</option
-            >
-            <option value="Paperback" selected={formData.format === 'Paperback'}
-              >Paperback</option
+            <option value="Physical" selected={formData.format === 'Physical'}
+              >Physical</option
             >
             <option value="E-book" selected={formData.format === 'E-book'}
               >E-book</option
@@ -268,6 +271,44 @@ if (Astro.request.method === 'POST') {
             class="form-input"
             value={formData.cost}
           />
+        </div>
+
+        <div>
+          <label for="startingPage" class="form-label">Starting Page</label>
+          <input
+            type="number"
+            id="startingPage"
+            name="startingPage"
+            min="0"
+            class="form-input"
+            value={formData.startingPage}
+          />
+        </div>
+
+        <div>
+          <label class="form-label mb-2">Finished</label>
+          <div class="flex items-center space-x-4">
+            <label class="inline-flex items-center">
+              <input
+                type="radio"
+                name="finished"
+                value="true"
+                class="form-radio"
+                checked={formData.finished}
+              />
+              <span class="ml-2">Yes</span>
+            </label>
+            <label class="inline-flex items-center">
+              <input
+                type="radio"
+                name="finished"
+                value="false"
+                class="form-radio"
+                checked={!formData.finished}
+              />
+              <span class="ml-2">No</span>
+            </label>
+          </div>
         </div>
       </div>
 

--- a/src/pages/import.astro
+++ b/src/pages/import.astro
@@ -160,7 +160,7 @@ import Layout from '../layouts/Layout.astro';
               <tr>
                 <td>Project Hail Mary</td>
                 <td>Andy Weir</td>
-                <td>Hardcover</td>
+                <td>Physical</td>
                 <td>496</td>
                 <td>9780593135204</td>
                 <td>Science Fiction</td>
@@ -170,7 +170,7 @@ import Layout from '../layouts/Layout.astro';
               <tr>
                 <td>Dune</td>
                 <td>Frank Herbert</td>
-                <td>Paperback</td>
+                <td>E-book</td>
                 <td>658</td>
                 <td>9780441172719</td>
                 <td>Science Fiction</td>

--- a/src/pages/reading-sessions/[id]/edit.astro
+++ b/src/pages/reading-sessions/[id]/edit.astro
@@ -153,7 +153,7 @@ const formattedDuration = formatDuration(session.duration);
         const updatedSession = {
           id: sessionId,
           bookId: formData.get('book'),
-          date: new Date(formData.get('date')).toISOString(),
+          date: formData.get('date'),
           pagesRead: parseInt(formData.get('pagesRead')),
           duration: durationSeconds,
           finished: formData.get('finished') === 'on',

--- a/src/pages/reading-sessions/index.astro
+++ b/src/pages/reading-sessions/index.astro
@@ -17,6 +17,25 @@ function formatDuration(seconds: number): string {
   ].join(':');
 }
 
+// Format date in UK format (DD/MM/YYYY)
+function formatDate(dateString: string): string {
+  try {
+    // Parse ISO date string
+    const date = new Date(dateString);
+
+    // Check if the date is valid
+    if (!isNaN(date.getTime())) {
+      return date.toLocaleDateString('en-GB');
+    }
+
+    // Return the original if we couldn't parse it
+    return dateString;
+  } catch (e) {
+    // If parsing fails, return the original
+    return dateString;
+  }
+}
+
 // Get book information for each session
 const sessionsWithBookInfo = await Promise.all(
   sessions.map(async (session) => {
@@ -101,9 +120,7 @@ sessionsWithBookInfo.sort((a, b) => {
 
                   return (
                     <tr class="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-slate-800">
-                      <td class="px-4 py-3">
-                        {new Date(session.date).toLocaleDateString()}
-                      </td>
+                      <td class="px-4 py-3">{formatDate(session.date)}</td>
                       <td class="px-4 py-3">
                         <a
                           href={`/books/${session.bookId}`}


### PR DESCRIPTION
- Created migration file to add `starting_page` (default 0) and `finished` (default false) columns to the `books` table. Fixes #7
- Updated schema definition for books to include new fields.
- Modified relevant API endpoints and forms to handle the new fields for book creation and editing.
- Enhanced reading session logic to update book status based on reading activity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added "Starting Page" and "Finished" fields to book creation and editing forms, allowing users to track where they began reading and whether a book is finished.
  - Book detail pages now display the starting page and reading status with a visual badge.
  - Importing data from sheets now supports these new fields and updates book status based on reading sessions.

- **Enhancements**
  - Reading progress calculations now account for the starting page.
  - Improved criteria for identifying "currently reading" books to include those with a starting page set.
  - Book format options in forms now use a single "Physical" option.

- **Bug Fixes**
  - Fixed duplicate "Genre" input in the book editing form.

- **Style**
  - Dates are now consistently displayed in UK format (DD/MM/YYYY) across book and reading session pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->