### PR TITLE
Document PageTurn domain model and agent conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,3 +102,17 @@ migrations/           # Drizzle migrations
 - When adding new DB queries, add them to `src/lib/db.ts` and keep API routes thin.
 - API routes follow REST-style patterns; use appropriate HTTP methods (GET, POST, PUT, PATCH, DELETE).
 - Avoid hardcoding secrets; use environment variables / wrangler secrets.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and specs are tracked in GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The canonical triage labels use their default names. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repository uses a single-context domain layout. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,229 @@
+# PageTurn
+
+PageTurn models a Reader's current and historical relationship with Works and Editions they own, borrow, access, or read.
+
+## Language
+
+**Reader**:
+The person whose library and reading activity PageTurn records.
+_Avoid_: User, account
+
+**Library**:
+A Reader's current and historical collection of Library Entries, including Editions they no longer hold but whose reading history they retain.
+_Avoid_: Inventory, collection
+
+**Work**:
+The intellectual creation shared by all of its published forms, with its canonical title, first-publication date, authorship, and Subjects.
+_Avoid_: Book
+
+**Edition**:
+A particular published volume or release containing one or more Works, with its own displayed title, language, publisher, publication date, format, Progress Unit, cover, and Edition Identifiers.
+_Avoid_: Book, copy, version
+
+**Edition Content**:
+The inclusion of a Work within an Edition, recording its order and optional position range. This allows one Edition to contain several Works while each Reading Attempt still targets one Work.
+_Avoid_: Contents, chapter
+
+**Abridged**:
+A classification on Edition Content indicating that material from its Work was intentionally shortened while remaining a presentation of the same Work.
+_Avoid_: Adaptation, summary
+
+**Adaptation**:
+A distinct Work that materially transforms a source Work rather than presenting it in another Edition.
+_Avoid_: Abridgement, edition
+
+**Edition Identifier**:
+A typed external identifier for an Edition, such as ISBN-10, ISBN-13, ASIN, OCLC, or a catalog-provider identifier. An Edition may have several, but a value is unique within its identifier namespace.
+_Avoid_: ISBN, book ID
+
+**Subject**:
+A normalized classification attached to a Work, with provenance retained from its source. A Work may have multiple Subjects.
+_Avoid_: Genre, tag, category
+
+**Catalog Merge**:
+The consolidation of duplicate Works, Editions, or Contributors into one canonical record. Existing references and source identifiers move to the canonical record, conflicting metadata is retained for review, and retired identifiers continue to redirect.
+_Avoid_: Deletion, deduplication
+
+**Contributor**:
+A person or organization credited for part of a Work or Edition.
+_Avoid_: Creator
+
+**Contribution**:
+The relationship between a Contributor and a Work or Edition, qualified by a role such as author, editor, translator, illustrator, or narrator.
+_Avoid_: Authorship
+
+**Gender**:
+A demographic classification recorded for a Contributor with explicit provenance when known. Unknown remains a meaningful value, and Gender is never inferred from a Contributor's name.
+_Avoid_: Sex, author sex
+
+**Library Entry**:
+A Reader's unique, enduring personal relationship with an Edition, created when they first hold or read it. It may exist without a Holding Period.
+_Avoid_: Book, inventory item
+
+**Recommendation**:
+One inbound suggestion connecting a Reader to a Work, optionally identifying its source and date. A Reader may retain several Recommendations for the same Work without a Library Entry.
+_Avoid_: Recommended, rating, review
+
+**Reading Session**:
+A completed, dated record of Reading Time spent on one Reading Attempt using one Edition that contains the attempt's Work. It never spans multiple Works; its first and final positions in the Edition are retained when known.
+_Avoid_: Session
+
+**Live Reading Session**:
+A temporary capture of a Reading Session using an active timer rather than retrospective entry. It becomes a Reading Session when completed, and a Reader may have only one active capture at a time.
+_Avoid_: Live read, timer
+
+**Finishing Session**:
+The Reading Session during which the Reader finished the associated Reading Attempt. It records the completion event; it is not the attempt's current status.
+_Avoid_: Finished session, completed session
+
+**Reading Attempt**:
+One intentional effort by a Reader to read a Work, with its own status, Work Progress, and Reading Sessions across one or more Editions. It is created explicitly rather than by adding a Library Entry; a Reader has at most one unfinished Reading Attempt per Work.
+_Avoid_: Read, reading
+
+**Attempt Interval**:
+The historical span from the start of a Reading Attempt until it becomes Finished or Abandoned. Corrections may add a Reading Session within this interval after termination, but later activity requires a new Reading Attempt.
+_Avoid_: Reading period
+
+**Not Started**:
+A reading status for a newly created Reading Attempt with no Reading Sessions. Saving its first Reading Session changes it to Currently Reading.
+_Avoid_: In progress
+
+**Currently Reading**:
+A reading status for a Reading Attempt with recorded prior progress or at least one Reading Session.
+_Avoid_: In progress
+
+**Finished**:
+A terminal reading status explicitly confirming that the Reader completed a Reading Attempt. Reaching an Edition's final position may suggest Finished but never sets it automatically, and the status remains authoritative even when no Finishing Session exists.
+_Avoid_: Complete, read
+
+**Abandoned**:
+A terminal reading status indicating that the Reader intentionally stopped a Reading Attempt without finishing it.
+_Avoid_: Did not finish, inactive, paused
+
+**Holding Period**:
+One continuous span during which a Reader possesses or can access one copy of a Library Entry's Edition. It records how the copy is held, when the period begins and ends, any Acquisition Cost, and an optional Holding End Reason; multiple copies have overlapping Holding Periods.
+_Avoid_: Ownership period, ownership history, acquisition
+
+**Holding End Reason**:
+Why a Holding Period ended, such as Sold, Gifted, Lost, Destroyed, Returned, Access Ended, or Other.
+_Avoid_: Deletion reason
+
+**Owned**:
+A Holding Period type indicating that ownership of the copy belongs to the Reader.
+_Avoid_: Active, available, held
+
+**Borrowed**:
+A Holding Period type indicating that the Reader temporarily possesses or can access a copy owned by someone else.
+_Avoid_: Owned, rented
+
+**Subscription Access**:
+A Holding Period type indicating that access to an Edition depends on an active subscription rather than ownership or a single loan.
+_Avoid_: Owned, borrowed
+
+**Removed**:
+A lifecycle outcome indicating that an Owned Holding Period ended because the Reader no longer owns that copy. Other Holding Periods may remain active, and the Library Entry and reading history remain intact.
+_Avoid_: Deleted, archived
+
+**Deletion**:
+Permanent erasure of a mistaken Library Entry or fulfillment of an explicit data-erasure request. Normal disposal, return, or loss ends a Holding Period instead.
+_Avoid_: Removal
+
+**Acquisition Cost**:
+The amount and currency paid to begin a Holding Period. Historical costs retain their original currencies and aggregate separately by currency unless an explicit conversion records its exchange rate and valuation date.
+_Avoid_: Cost, price
+
+**Progress Unit**:
+The unit an Edition uses to express progress: Page for print and e-book Editions, and Time Position for audiobook Editions.
+_Avoid_: Page count
+
+**Edition Length**:
+The optional total number of Progress Units in an Edition. An unknown Edition Length permits activity and positions but prevents Edition-derived percentages, native-unit completion speed, and finish estimates.
+_Avoid_: Page count, duration
+
+**Content Start Position**:
+The first position in an Edition that the Reader considers readable or listenable content for one Reading Attempt. Earlier material advances the Reading Position but does not count as reading effort.
+_Avoid_: Starting page, reading baseline
+
+**Session Start Position**:
+The first position read or heard during a Reading Session, expressed in the Edition's Progress Unit.
+_Avoid_: Starting page, current page
+
+**Session End Position**:
+The final position read or heard during a Reading Session, expressed in the Edition's Progress Unit.
+_Avoid_: Ending page, current page
+
+**Reading Time**:
+The wall-clock time from the start to the end of a Reading Session excluding paused intervals. A manually logged session records the Reader's best estimate of the same measure.
+_Avoid_: Duration, media time, time position
+
+**Reading Date**:
+The Reader-local calendar date on which a Reading Session occurred. Live sessions may additionally retain their start and end instants and paused intervals.
+_Avoid_: Created date, session timestamp
+
+**Pages Read**:
+The number of page interactions recorded as reading effort during a Reading Session. Reread pages count again; skipped pages do not.
+_Avoid_: Reading position, current page
+
+**Reading Position**:
+The furthest position the Reader has reached within one Edition during a Reading Attempt, expressed in that Edition's Progress Unit and including material passed before its Content Start Position.
+_Avoid_: Pages read, current page
+
+**Work Progress**:
+The furthest overall progress a Reader has confirmed through a Work during one Reading Attempt. Edition positions and corrected Sessions may suggest a review, but incompatible positions are never added and confirmed progress is never silently reduced.
+_Avoid_: Reading position, pages read
+
+**Reading Speed**:
+Progress through one Edition measured in its native Progress Unit per hour of Reading Time. Cross-format summaries compare Reading Time and Work Progress change instead of combining native-unit speeds.
+_Avoid_: Reading pace
+
+**Estimated Finish**:
+A forecast for an active Reading Attempt based on recent Work Progress velocity from at least two progress-bearing Reading Sessions. It is omitted when the available progress evidence is insufficient.
+_Avoid_: Finish date, completion date
+
+**Works in Library**:
+The number of distinct Works represented by a Reader's Library Entries.
+_Avoid_: Total books
+
+**Editions in Library**:
+The number of distinct Library Entries in a Reader's Library.
+_Avoid_: Total books
+
+**Active Holdings**:
+The number of copies or access entitlements represented by Holding Periods that have not ended.
+_Avoid_: Total books, books owned
+
+**Time Position**:
+An elapsed point within an audiobook Edition used to express Reading Position. It is distinct from the time a Reader actually spends listening, which may vary with playback speed.
+_Avoid_: Reading time, duration
+
+**Library Composition**:
+A demographic view of the unique Works represented by a Reader's active Owned Holding Periods, grouped by Author Gender.
+_Avoid_: Reading exposure
+
+**Reading Exposure**:
+A demographic view of Reading Attempts with activity during a selected period, weighted by tracked reading time and grouped by Author Gender.
+_Avoid_: Library composition
+
+**Demographic Insight**:
+A private aggregate view of Library Composition or Reading Exposure intended to help a Reader reflect on their reading biases.
+_Avoid_: Bias score, diversity score
+
+**Representation Rate**:
+The proportion of Works or tracked reading time featuring at least one Author in a Gender category. A multi-author Work counts fully in every represented category, so Representation Rates may overlap and need not total 100%.
+_Avoid_: Gender split, demographic share
+
+**Finished Attempts**:
+The number of Reading Attempts that became Finished, including rereads of the same Work.
+_Avoid_: Books finished
+
+**Unique Works Finished**:
+The number of distinct Works for which a Reader has at least one Finished Reading Attempt.
+_Avoid_: Books finished
+
+**Import Batch**:
+A staged set of catalog, Library, or reading-history records that is validated and reviewed before being committed atomically. Identifier matches take precedence, while ambiguous title and Contributor matches require the Reader's resolution.
+_Avoid_: Import, spreadsheet upload
+
+**Data Export**:
+A machine-readable copy of a Reader's private PageTurn data and referenced catalog identifiers. It is offered before account deletion but never delays an explicit erasure request.
+_Avoid_: Backup, spreadsheet export

--- a/docs/adr/0001-own-catalog-metadata.md
+++ b/docs/adr/0001-own-catalog-metadata.md
@@ -1,0 +1,3 @@
+# Own normalized catalog metadata
+
+PageTurn stores Works, Editions, Edition Contents, Contributors, and Contributions in its own catalog and treats external metadata as suggestions rather than authoritative records. An Edition may contain multiple Works, while Library Entries reference Editions. Open Library is the initial provider behind a provider-neutral adapter; imported metadata is cached locally and retains its source identifier for attribution and refreshes. Readers may create sparse missing records—a Work needs a title, while an Edition needs its Work association, format, and Progress Unit—and enrich them later. Trusted imports or administrators govern changes to shared records and merge duplicates into canonical records without breaking existing references.

--- a/docs/adr/0002-preserve-reading-and-ownership-history.md
+++ b/docs/adr/0002-preserve-reading-and-ownership-history.md
@@ -1,0 +1,3 @@
+# Preserve reading and ownership history as episodes
+
+A Library Entry is the enduring relationship between a Reader and an Edition rather than one mutable holding event. Reacquisitions, repeated loans, and simultaneously held copies create distinct, potentially overlapping Holding Periods. Reading Attempts instead relate a Reader to a Work and preserve rereads, abandoned attempts, completions, and progress rather than overwriting history or inflating one progress total beyond 100%.

--- a/docs/adr/0003-use-format-specific-progress-units.md
+++ b/docs/adr/0003-use-format-specific-progress-units.md
@@ -1,0 +1,3 @@
+# Use format-specific progress units
+
+Each Edition declares the unit used for positions and total progress: pages for print and e-book Editions, and media time for audiobook Editions. Reading Sessions keep optional start and end positions in that unit while Reading Time remains the common measure of effort. Native Reading Speed is calculated only within an Edition's unit; cross-format summaries compare Reading Time and Work Progress change without pretending that pages and audiobook positions are interchangeable.

--- a/docs/adr/0004-keep-demographic-insights-private-and-provenanced.md
+++ b/docs/adr/0004-keep-demographic-insights-private-and-provenanced.md
@@ -1,0 +1,3 @@
+# Keep demographic insights private and provenanced
+
+PageTurn offers private Demographic Insights using Contributor Gender with provenance retained when known, Unknown kept visible, and Gender never inferred from names. Library Composition measures unique Works in active Owned holdings, Reading Exposure measures tracked reading time, both default to Author Contributions, and multi-author Works count fully in every represented Gender category through overlapping Representation Rates. Only trusted imports or administrators may change shared Gender data; Readers explicitly choose whether to share an aggregate insight, never its underlying Library or Reading Sessions.

--- a/docs/adr/0005-allow-reading-attempts-across-editions.md
+++ b/docs/adr/0005-allow-reading-attempts-across-editions.md
@@ -1,0 +1,3 @@
+# Allow Reading Attempts across Editions
+
+A Reading Attempt represents one intentional effort by a Reader to read a Work and may span multiple Editions, such as alternating between paperback and audiobook. Each Reading Session identifies its Edition and retains positions in that Edition's native Progress Unit; incompatible positions are never summed. PageTurn automatically advances Work Progress from a consistent Edition, suggests confirmation when Editions change or materially disagree, always permits manual correction, and never reduces progress merely because earlier material was revisited. A Reader may have only one unfinished attempt for a Work at a time.

--- a/docs/adr/0006-keep-reader-data-private-and-shared-catalog-durable.md
+++ b/docs/adr/0006-keep-reader-data-private-and-shared-catalog-durable.md
@@ -1,0 +1,3 @@
+# Keep Reader data private and the shared catalog durable
+
+A Reader's Library, Recommendations, Holding Periods, Reading Attempts, Sessions, and statistics are private unless the Reader explicitly shares a scoped aggregate, list, or item. PageTurn offers a machine-readable export before account deletion without delaying an explicit erasure request. Deletion erases the Reader's private data and unreferenced personal catalog drafts; shared catalog records used by others remain with the departed Reader's provenance anonymized, so deleting one account cannot break other Libraries.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,32 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, proceed silently. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a single-context repository:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When output names a domain concept—in an issue title, refactor proposal, hypothesis, or test name—use the term defined in `CONTEXT.md`. Avoid synonyms that the glossary explicitly rejects.
+
+If the needed concept isn't in the glossary, reconsider whether it reflects project language or note the gap for `/domain-modeling`.
+
+## Flag ADR conflicts
+
+If output contradicts an existing ADR, surface the conflict explicitly rather than silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's native issue dependencies. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric database ID. Where dependencies aren't available, use a `Blocked by: #<n>` line at the top of the child body.
+- **Frontier query**: list the map's open children, then drop claimed tickets and tickets with open blockers. The first remaining ticket in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: comment with the answer, close the child, then append a context pointer to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                   |
+| -------------------------- | -------------------- | ----------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue   |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent   |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation             |
+| `wontfix`                  | `wontfix`            | Will not be actioned                      |
+
+When a skill mentions a role, use the corresponding label string from this table.
+
+Edit the right-hand column to match the vocabulary used by the issue tracker.


### PR DESCRIPTION
## Summary

- configure repository guidance for GitHub issues, triage labels, and domain documentation
- define the PageTurn glossary around Works, Editions, Library history, Reading Attempts, and Reading Sessions
- record six architectural decisions covering catalog ownership, historical episodes, progress units, demographic privacy, cross-Edition attempts, and Reader-data lifecycle

## Verification

- git diff --check origin/main...HEAD
- documentation-only change; application build and tests were not run

## Related

Supports the implementation plan in #252 without closing it.