### PR TITLE
Establish the full-stack acceptance seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  acceptance:
+    name: Build and acceptance suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and run acceptance suite
+        run: pnpm run test:acceptance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ migrations/           # Drizzle migrations
 | `pnpm run dev` | Local dev at `localhost:4321` |
 | `pnpm run build` | Build for production |
 | `pnpm run preview` | Build and preview with Wrangler Pages locally |
+| `pnpm run test:acceptance` | Build, then run the acceptance suite against the built Worker on an isolated D1 (see `docs/acceptance-testing.md`) |
 | `pnpm run deploy` | Build and deploy to Cloudflare Pages |
 | `pnpm run cf-typegen` | Regenerate Cloudflare binding/runtime types |
 | `pnpm run db:generate` | Generate Drizzle migrations |

--- a/docs/acceptance-testing.md
+++ b/docs/acceptance-testing.md
@@ -1,0 +1,63 @@
+# Acceptance testing
+
+The acceptance suite is PageTurn's behavioral safety net at the deployed
+application boundary. It exercises the built Astro Worker over HTTP — real
+routing, middleware, authentication, and D1 access — rather than importing
+application modules into the test process.
+
+## Running the suite
+
+```sh
+pnpm run test:acceptance
+```
+
+That single command, locally and in CI:
+
+1. Builds the application (`astro check && astro build`), so the existing
+   build/type-check verification runs alongside the suite.
+2. Provisions an isolated local D1 database in a temp directory and applies
+   every migration in `migrations/`.
+3. Boots the built Worker with `wrangler dev` on a free port, configured for
+   the local origin.
+4. Runs the Vitest specs in `tests/acceptance/` against the live HTTP
+   boundary.
+5. Stops the Worker and deletes the temp database, whether or not the tests
+   pass.
+
+Nothing persists between runs and no shared or remote state is touched, so the
+command is safe for unattended CI execution (see
+`.github/workflows/ci.yml`).
+
+While iterating on tests only, skip the rebuild with:
+
+```sh
+ACCEPTANCE_SKIP_BUILD=1 pnpm run test:acceptance
+```
+
+## How fixtures authenticate
+
+Production sign-in is social OAuth only (GitHub/Google), which an unattended
+suite cannot drive. The suite therefore uses better-auth's credential
+endpoints as its seam: `src/lib/auth.ts` enables `emailAndPassword` **only**
+when the `ACCEPTANCE_TEST_AUTH` variable is `"true"`. The harness sets that
+variable on the local Worker; deployed configuration leaves it empty, so the
+endpoints do not exist in production or previews.
+
+Everything past sign-up is the real authentication contract: fixtures receive
+genuine better-auth session cookies over HTTP, and every request is validated
+by the production middleware and session store. The administrator fixture is
+created the same way, promoted to the `admin` role, and then signs in again so
+its session carries the role.
+
+## Rules for writing specs
+
+- Assert only on HTTP responses and rendered pages. Tests must not import
+  application code, inspect tables, or call ORM helpers.
+- Direct database access is allowed **only** inside
+  `tests/acceptance/helpers.ts`, and only for fixture setup (e.g. promoting an
+  administrator) and cleanup (removing fixture Readers).
+- Create a fresh fixture per spec file with `signUpFixture(...)` and remove it
+  in `afterAll` with `deleteFixtures(...)`. Fixture emails are randomized, so
+  specs stay independent.
+- Use `request(path, { cookie })` from the helpers; it never follows
+  redirects, so the authentication boundary itself is assertable.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro build && astro preview",
+    "test:acceptance": "node scripts/acceptance.mjs",
     "astro": "astro",
     "deploy": "astro build && wrangler deploy",
     "cf-typegen": "wrangler types",
@@ -39,6 +40,7 @@
     "tailwindcss": "4.3.3",
     "ts-node": "10.9.2",
     "typescript": "5.9.3",
+    "vitest": "4.1.11",
     "wrangler": "4.111.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 7.0.9(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.21.0)(yaml@2.8.3)
       better-auth:
         specifier: 1.6.30
-        version: 1.6.30(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(prisma@6.6.0(typescript@5.9.3)))(prisma@6.6.0(typescript@5.9.3))
+        version: 1.6.30(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(prisma@6.6.0(typescript@5.9.3)))(prisma@6.6.0(typescript@5.9.3))(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(prisma@6.6.0(typescript@5.9.3))
@@ -60,6 +60,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: 4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
         specifier: 4.111.0
         version: 4.111.0
@@ -1765,6 +1768,12 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1796,6 +1805,35 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1868,6 +1906,10 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astro@7.0.9:
     resolution: {integrity: sha512-WB5pA4LLQnmqjBh6EIu0z8aUV4q2/AoThgSZq57Rsp+oqqvPu7OwZ5eF+W4ku20TUTxIhiJW8dccuGvJPiW2UA==}
@@ -1984,6 +2026,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -2023,6 +2069,9 @@ packages:
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -2282,12 +2331,19 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2834,6 +2890,9 @@ packages:
     resolution: {integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -2860,6 +2919,12 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -2909,6 +2974,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.14:
     resolution: {integrity: sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -2920,6 +2988,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3135,6 +3207,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -3233,6 +3346,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workerd@1.20260617.1:
@@ -4537,6 +4655,13 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -4570,6 +4695,47 @@ snapshots:
       '@types/node': 24.13.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -4654,6 +4820,8 @@ snapshots:
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
 
   astro@7.0.9(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.3)(jiti@2.7.0)(rollup@4.62.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -4753,7 +4921,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-auth@1.6.30(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(prisma@6.6.0(typescript@5.9.3)))(prisma@6.6.0(typescript@5.9.3)):
+  better-auth@1.6.30(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(prisma@6.6.0(typescript@5.9.3)))(prisma@6.6.0(typescript@5.9.3))(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.30(@better-auth/core@1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(prisma@6.6.0(typescript@5.9.3)))
@@ -4778,6 +4946,7 @@ snapshots:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.28.17)(prisma@6.6.0(typescript@5.9.3))
       prisma: 6.6.0(typescript@5.9.3)
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -4819,6 +4988,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -4848,6 +5019,8 @@ snapshots:
   commander@11.1.0: {}
 
   common-ancestor-path@2.0.0: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
@@ -5107,9 +5280,15 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   eventemitter3@5.0.4: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   extend@3.0.2: {}
 
@@ -5721,6 +5900,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -5743,6 +5924,10 @@ snapshots:
   source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   string-width@7.2.0:
     dependencies:
@@ -5803,6 +5988,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.14: {}
 
   tinyexec@1.2.4: {}
@@ -5811,6 +5998,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.1: {}
 
   trim-lines@3.0.1: {}
 
@@ -5960,6 +6149,34 @@ snapshots:
     optionalDependencies:
       vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.1.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - msw
+
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.5
@@ -6062,6 +6279,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260617.1:
     optionalDependencies:

--- a/scripts/acceptance.mjs
+++ b/scripts/acceptance.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Acceptance test harness.
+ *
+ * Runs the full acceptance seam end to end:
+ *   1. Builds the application (astro check + astro build), unless
+ *      ACCEPTANCE_SKIP_BUILD=1 is set for local iteration on tests only.
+ *   2. Provisions an isolated local D1 database in a temp directory and
+ *      applies every migration.
+ *   3. Boots the built Worker with `wrangler dev`, pointing better-auth at
+ *      the local origin and enabling the credential auth seam for fixtures.
+ *   4. Runs the Vitest suite in tests/acceptance against the live HTTP
+ *      boundary.
+ *   5. Tears the Worker down and deletes the temp database, deterministically,
+ *      whatever the test outcome.
+ *
+ * Usage: pnpm run test:acceptance
+ */
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      stdio: "inherit",
+      ...options,
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve(undefined);
+      } else {
+        reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForReady(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { redirect: "manual" });
+      if (response.status === 200) {
+        return;
+      }
+      lastError = new Error(`server responded with ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 500));
+  }
+  throw new Error(`Server at ${url} did not become ready: ${lastError}`);
+}
+
+function signalServerGroup(child, signal) {
+  // Negative PID signals the whole process group, so workerd children die too.
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    child.kill(signal);
+  }
+}
+
+async function stopServer(child) {
+  if (child.exitCode !== null) {
+    return;
+  }
+  const exited = new Promise((resolve) => child.once("exit", resolve));
+  signalServerGroup(child, "SIGTERM");
+  const timeout = new Promise((resolve) => setTimeout(resolve, 10_000, "timeout"));
+  if ((await Promise.race([exited, timeout])) === "timeout") {
+    signalServerGroup(child, "SIGKILL");
+    await exited;
+  }
+}
+
+const skipBuild = process.env.ACCEPTANCE_SKIP_BUILD === "1";
+if (skipBuild) {
+  console.log("[acceptance] ACCEPTANCE_SKIP_BUILD=1, reusing existing dist/");
+} else {
+  console.log("[acceptance] Building application (astro check + astro build)...");
+  await run("pnpm", ["run", "build"]);
+}
+
+const persistDir = mkdtempSync(path.join(os.tmpdir(), "pageturn-acceptance-"));
+let server;
+let torndown = false;
+
+async function teardown() {
+  if (torndown) {
+    return;
+  }
+  torndown = true;
+  if (server) {
+    console.log("[acceptance] Stopping worker");
+    await stopServer(server);
+  }
+  rmSync(persistDir, { recursive: true, force: true });
+  console.log("[acceptance] Cleaned up isolated database");
+}
+
+// try/finally does not run on signals; make Ctrl+C and CI cancellation clean
+// up the worker process group and the temp database too.
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    teardown().finally(() => process.exit(1));
+  });
+}
+
+try {
+  console.log(`[acceptance] Provisioning isolated D1 database in ${persistDir}`);
+  await run("pnpm", [
+    "exec",
+    "wrangler",
+    "d1",
+    "migrations",
+    "apply",
+    "page-turn",
+    "--local",
+    "--persist-to",
+    persistDir,
+  ], { env: { ...process.env, WRANGLER_SEND_METRICS: "false" } });
+
+  const port = await findFreePort();
+  const baseURL = `http://127.0.0.1:${port}`;
+  const authSecret = randomBytes(32).toString("hex");
+
+  console.log(`[acceptance] Starting worker at ${baseURL}`);
+  const vars = {
+    BETTER_AUTH_URL: baseURL,
+    AUTH_TRUSTED_ORIGINS: baseURL,
+    ACCEPTANCE_TEST_AUTH: "true",
+    BETTER_AUTH_SECRET: authSecret,
+    // getAuth() requires OAuth credentials to exist; the suite never follows
+    // a social login, so placeholder values are enough.
+    GITHUB_CLIENT_ID: "acceptance-placeholder",
+    GITHUB_CLIENT_SECRET: "acceptance-placeholder",
+    GOOGLE_CLIENT_ID: "acceptance-placeholder",
+    GOOGLE_CLIENT_SECRET: "acceptance-placeholder",
+  };
+  const varArgs = Object.entries(vars).flatMap(([key, value]) => ["--var", `${key}:${value}`]);
+  server = spawn(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "dev",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--persist-to",
+      persistDir,
+      ...varArgs,
+    ],
+    {
+      cwd: repoRoot,
+      stdio: "inherit",
+      detached: true,
+      env: { ...process.env, CI: "true", WRANGLER_SEND_METRICS: "false" },
+    }
+  );
+  server.on("error", (error) => {
+    console.error("[acceptance] Failed to start wrangler dev:", error);
+  });
+
+  await waitForReady(`${baseURL}/login`, 90_000);
+  console.log("[acceptance] Worker is ready, running acceptance suite");
+
+  await run("pnpm", ["exec", "vitest", "run"], {
+    env: {
+      ...process.env,
+      ACCEPTANCE_BASE_URL: baseURL,
+      ACCEPTANCE_PERSIST_DIR: persistDir,
+    },
+  });
+  console.log("[acceptance] Acceptance suite passed");
+} finally {
+  await teardown();
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -274,6 +274,15 @@ function createRuntimeAuth(env: Env, baseURL: string, cookieDomain?: string) {
   return betterAuth({
     secret: env.OAUTH_PROXY_SECRET || env.BETTER_AUTH_SECRET,
     baseURL,
+    // Credential sign-in exists solely so the acceptance suite can authenticate
+    // fixtures without an external OAuth provider. ACCEPTANCE_TEST_AUTH is never
+    // set in deployed configuration, so these endpoints stay disabled in
+    // production and previews.
+    // The cast keeps this comparison valid even when `wrangler types` narrows
+    // the var to its literal default of "".
+    emailAndPassword: {
+      enabled: (env.ACCEPTANCE_TEST_AUTH as string | undefined) === "true",
+    },
     trustedOrigins: (request) => {
       const origins = [env.BETTER_AUTH_URL];
       const requestOrigin = request?.headers.get("Origin") ?? null;

--- a/tests/acceptance/admin-access.test.ts
+++ b/tests/acceptance/admin-access.test.ts
@@ -1,0 +1,44 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  deleteFixtures,
+  promoteToAdmin,
+  request,
+  signInFixture,
+  signUpFixture,
+  type Fixture,
+} from './helpers';
+
+describe('administrator access', () => {
+  let admin: Fixture;
+  let reader: Fixture;
+
+  beforeAll(async () => {
+    admin = await signUpFixture('admin');
+    reader = await signUpFixture('reader');
+    promoteToAdmin(admin);
+    // Re-authenticate after promotion so the session reflects the admin role.
+    admin.cookie = await signInFixture(admin);
+  });
+
+  afterAll(() => {
+    deleteFixtures([admin, reader]);
+  });
+
+  it('shows the admin dashboard to an administrator', async () => {
+    const response = await request('/admin', { cookie: admin.cookie });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('User Administration');
+  });
+
+  it('redirects a plain Reader away from the admin dashboard', async () => {
+    const response = await request('/admin', { cookie: reader.cookie });
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/');
+  });
+
+  it('redirects unauthenticated visitors to the login page', async () => {
+    const response = await request('/admin');
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/login');
+  });
+});

--- a/tests/acceptance/helpers.ts
+++ b/tests/acceptance/helpers.ts
@@ -1,0 +1,167 @@
+/**
+ * Fixture and HTTP helpers for the acceptance suite.
+ *
+ * All assertions in the suite go through the deployed HTTP boundary. Direct
+ * database access is confined to this file and used only for fixture setup
+ * (promoting a fixture to administrator) and cleanup (removing fixture
+ * Readers), never for assertions.
+ */
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+export const baseURL = requiredEnv('ACCEPTANCE_BASE_URL');
+const persistDir = requiredEnv('ACCEPTANCE_PERSIST_DIR');
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set. Run the suite via \`pnpm run test:acceptance\`.`
+    );
+  }
+  return value;
+}
+
+export interface RequestOptions {
+  method?: string;
+  cookie?: string;
+  body?: unknown;
+}
+
+/**
+ * Sends a request to the running worker. Redirects are never followed so the
+ * suite can assert on the authentication boundary itself.
+ */
+export async function request(
+  pathname: string,
+  options: RequestOptions = {}
+): Promise<Response> {
+  const headers: Record<string, string> = { Origin: baseURL };
+  if (options.cookie) {
+    headers.Cookie = options.cookie;
+  }
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+  return fetch(`${baseURL}${pathname}`, {
+    method: options.method ?? 'GET',
+    headers,
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    redirect: 'manual',
+  });
+}
+
+export interface Fixture {
+  name: string;
+  email: string;
+  password: string;
+  /** Cookie header value carrying the real better-auth session. */
+  cookie: string;
+}
+
+/**
+ * Registers a fixture through the application's real authentication contract
+ * (better-auth's credential endpoint, enabled only under ACCEPTANCE_TEST_AUTH)
+ * and returns the session cookie issued by the application.
+ */
+export async function signUpFixture(prefix: string): Promise<Fixture> {
+  const name = `${prefix} fixture`;
+  const email = `${prefix}-${crypto.randomUUID()}@acceptance.invalid`;
+  const password = `pw-${crypto.randomUUID()}`;
+  const cookie = await credentialRequest('/api/auth/sign-up/email', {
+    name,
+    email,
+    password,
+  });
+  return { name, email, password, cookie };
+}
+
+/**
+ * Signs an existing fixture in through the real credential endpoint and
+ * returns a fresh session cookie.
+ */
+export async function signInFixture(fixture: Fixture): Promise<string> {
+  return credentialRequest('/api/auth/sign-in/email', {
+    email: fixture.email,
+    password: fixture.password,
+  });
+}
+
+async function credentialRequest(
+  pathname: string,
+  body: Record<string, string>
+): Promise<string> {
+  const response = await request(pathname, { method: 'POST', body });
+  if (!response.ok) {
+    throw new Error(
+      `${pathname} failed with ${response.status}: ${await response.text()}`
+    );
+  }
+  return sessionCookie(response);
+}
+
+function sessionCookie(response: Response): string {
+  const pairs = response.headers
+    .getSetCookie()
+    .map((header) => header.split(';')[0].trim())
+    // Keep only cookies that carry a value; a bare `name=` is a deletion.
+    .filter((pair) => /=.+/.test(pair));
+  if (pairs.length === 0) {
+    throw new Error('Response did not set a session cookie');
+  }
+  return pairs.join('; ');
+}
+
+function openDatabase(): DatabaseSync {
+  const d1Dir = path.join(persistDir, 'v3', 'd1', 'miniflare-D1DatabaseObject');
+  const file = readdirSync(d1Dir).find((entry) => entry.endsWith('.sqlite'));
+  if (!file) {
+    throw new Error(`No D1 database file found under ${d1Dir}`);
+  }
+  const db = new DatabaseSync(path.join(d1Dir, file));
+  db.exec('PRAGMA busy_timeout = 5000');
+  db.exec('PRAGMA foreign_keys = ON');
+  return db;
+}
+
+/** Fixture setup only: grants the administrator role to a fixture user. */
+export function promoteToAdmin(fixture: Fixture): void {
+  const db = openDatabase();
+  try {
+    const result = db
+      .prepare("UPDATE user SET role = 'admin' WHERE email = ?")
+      .run(fixture.email);
+    if (Number(result.changes) !== 1) {
+      throw new Error(`Expected to promote exactly one user, got ${result.changes}`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/** Fixture cleanup only: removes fixture Readers and their dependent records. */
+export function deleteFixtures(fixtures: Fixture[]): void {
+  if (fixtures.length === 0) {
+    return;
+  }
+  const db = openDatabase();
+  try {
+    // The deployed schema's user_id foreign keys predate ON DELETE CASCADE,
+    // so dependent rows are removed explicitly, leaves first.
+    const statements = [
+      'DELETE FROM reading_sessions WHERE user_id IN (SELECT id FROM user WHERE email = ?)',
+      'DELETE FROM books WHERE user_id IN (SELECT id FROM user WHERE email = ?)',
+      'DELETE FROM session WHERE user_id IN (SELECT id FROM user WHERE email = ?)',
+      'DELETE FROM account WHERE user_id IN (SELECT id FROM user WHERE email = ?)',
+      'DELETE FROM user WHERE email = ?',
+    ].map((sql) => db.prepare(sql));
+    for (const fixture of fixtures) {
+      for (const statement of statements) {
+        statement.run(fixture.email);
+      }
+    }
+  } finally {
+    db.close();
+  }
+}

--- a/tests/acceptance/library-workflow.test.ts
+++ b/tests/acceptance/library-workflow.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  deleteFixtures,
+  request,
+  signUpFixture,
+  type Fixture,
+} from './helpers';
+
+interface BookResponse {
+  id: string;
+  title: string;
+  author: string;
+}
+
+describe('library workflow', () => {
+  let reader: Fixture;
+  let otherReader: Fixture;
+  const bookTitle = `Acceptance Novel ${crypto.randomUUID()}`;
+
+  beforeAll(async () => {
+    reader = await signUpFixture('reader');
+    otherReader = await signUpFixture('other-reader');
+  });
+
+  afterAll(() => {
+    deleteFixtures([reader, otherReader]);
+  });
+
+  it('lets a Reader add an entry to their Library', async () => {
+    const response = await request('/api/books', {
+      method: 'POST',
+      cookie: reader.cookie,
+      body: {
+        title: bookTitle,
+        author: 'Accepta Tester',
+        format: 'Paperback',
+        pageCount: 320,
+        isbn: '9780000000000',
+        authorSex: 'Unknown',
+        recommended: false,
+        genre: 'Fiction',
+        publishedYear: 2020,
+        publisher: 'Acceptance Press',
+        dateAcquired: '2026-08-01',
+        dateRemoved: null,
+        cost: 9.99,
+        startingPage: 0,
+        finished: false,
+      },
+    });
+    expect(response.status).toBe(201);
+    const created = (await response.json()) as BookResponse;
+    expect(created.id).toBeTruthy();
+    expect(created.title).toBe(bookTitle);
+  });
+
+  it('lists the entry through the API for its owning Reader', async () => {
+    const response = await request('/api/books', { cookie: reader.cookie });
+    expect(response.status).toBe(200);
+    const books = (await response.json()) as BookResponse[];
+    expect(books.map((book) => book.title)).toContain(bookTitle);
+  });
+
+  it('renders the entry on the Library page', async () => {
+    const response = await request('/books', { cookie: reader.cookie });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain(bookTitle);
+  });
+
+  it('keeps the entry out of another Reader\'s Library', async () => {
+    const response = await request('/api/books', { cookie: otherReader.cookie });
+    expect(response.status).toBe(200);
+    const books = (await response.json()) as BookResponse[];
+    expect(books.map((book) => book.title)).not.toContain(bookTitle);
+  });
+});

--- a/tests/acceptance/unauthenticated-boundary.test.ts
+++ b/tests/acceptance/unauthenticated-boundary.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { request } from './helpers';
+
+describe('unauthenticated boundary', () => {
+  it('rejects API requests without a session', async () => {
+    const response = await request('/api/books');
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('redirects page requests without a session to the login page', async () => {
+    const response = await request('/books');
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/login');
+  });
+
+  it('serves the login page without a session', async () => {
+    const response = await request('/login');
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('PageTurn');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/acceptance/**/*.test.ts'],
+    // The suite shares one worker and one D1 database; run files sequentially
+    // so fixture setup and cleanup stay deterministic.
+    fileParallelism: false,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -7,6 +7,7 @@ interface __BaseEnv_Env {
 	AUTH_PREVIEW_URL: "";
 	AUTH_TRUSTED_ORIGINS: "https://pageturn.moverperfect.com";
 	WORKERS_PREVIEW_HOST_SUFFIX: "-pageturn.moverperfect.workers.dev";
+	ACCEPTANCE_TEST_AUTH: string;
 	BETTER_AUTH_SECRET: string;
 	BETTER_AUTH_URL: string;
 	GITHUB_CLIENT_ID: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,7 +20,10 @@
     // Dynamic Workers previews use the request URL as the OAuth proxy current URL.
     "AUTH_PREVIEW_URL": "",
     "AUTH_TRUSTED_ORIGINS": "https://pageturn.moverperfect.com",
-    "WORKERS_PREVIEW_HOST_SUFFIX": "-pageturn.moverperfect.workers.dev"
+    "WORKERS_PREVIEW_HOST_SUFFIX": "-pageturn.moverperfect.workers.dev",
+    // Set to "true" only by the acceptance harness (scripts/acceptance.mjs) to
+    // enable credential sign-in for test fixtures. Never enable in deployments.
+    "ACCEPTANCE_TEST_AUTH": ""
   },
 
   /**


### PR DESCRIPTION
Closes #253

## What this adds

A single documented command, `pnpm run test:acceptance`, that:

1. Builds the application (`astro check && astro build`), keeping the existing build/type-check verification in the loop.
2. Provisions an isolated local D1 database in a temp directory and applies every migration.
3. Boots the built Astro Worker with `wrangler dev` on a free port.
4. Runs HTTP-level Vitest specs in `tests/acceptance/` against the live boundary.
5. Tears down the Worker and deletes the temp database deterministically, including on SIGINT/SIGTERM.

A new GitHub Actions workflow (`.github/workflows/ci.yml`) runs the same command unattended (the repo previously had no CI). Full docs in `docs/acceptance-testing.md`.

## Coverage

- **Unauthenticated boundary**: `/api/books` returns 401; pages redirect to `/login`; `/login` is served.
- **Reader Library workflow**: create an entry via `POST /api/books`, list it via the API, see it rendered on `/books`, and confirm another Reader cannot see it.
- **Administrator access**: `/admin` renders for an administrator, redirects a plain Reader home, and redirects unauthenticated visitors to `/login`.

All assertions are on HTTP responses and rendered pages; no test imports application code or inspects tables.

## How fixtures authenticate

Production sign-in is GitHub/Google OAuth only, which an unattended suite cannot drive. The seam: `src/lib/auth.ts` enables better-auth's `emailAndPassword` endpoints **only** when `ACCEPTANCE_TEST_AUTH` is `"true"`, which only the harness sets — deployed configuration leaves it empty, so the endpoints do not exist in production or previews. Past sign-in, everything is the production path: real session cookies, real middleware validation, real admin-role checks. Direct DB access is confined to `tests/acceptance/helpers.ts` for fixture setup (admin promotion) and cleanup, per the issue's constraint.

## Found along the way

`books.user_id` and `reading_sessions.user_id` were added by migrations without `ON DELETE CASCADE`, though `src/lib/schema.ts` declares cascade — filed as #291.

## Verification

Full pipeline run: `astro check` 0 errors, 3 test files / 10 tests passed, clean teardown. Reviewed with the two-axis code-review skill (standards + spec); all confirmed findings fixed.