### PR TITLE
Clear the shutdown timer after the worker exits

### DIFF
--- a/scripts/acceptance.mjs
+++ b/scripts/acceptance.mjs
@@ -88,11 +88,17 @@ async function stopServer(child) {
   }
   const exited = new Promise((resolve) => child.once("exit", resolve));
   signalServerGroup(child, "SIGTERM");
-  const timeout = new Promise((resolve) => setTimeout(resolve, 10_000, "timeout"));
+  let timer;
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(resolve, 10_000, "timeout");
+  });
   if ((await Promise.race([exited, timeout])) === "timeout") {
     signalServerGroup(child, "SIGKILL");
     await exited;
   }
+  // The losing timer would otherwise keep the event loop (and CI job) alive
+  // for the rest of the 10 seconds.
+  clearTimeout(timer);
 }
 
 const skipBuild = process.env.ACCEPTANCE_SKIP_BUILD === "1";


### PR DESCRIPTION
Follow-up to the codex review comment on #292 (missed before merge).

`stopServer` in `scripts/acceptance.mjs` raced the worker's exit against a 10-second SIGKILL fallback, but never cancelled the losing timer. On every normal run the worker exits within a second or two, leaving the timer active — and an active `setTimeout` keeps Node's event loop alive, so the script (and each CI job) idled for the remaining ~9 seconds after teardown had already finished.

The timer handle is now retained and cleared once the race settles.

**Verification:** `ACCEPTANCE_SKIP_BUILD=1 pnpm run test:acceptance` passes (3 files / 10 tests) and the entire run — provision, boot, tests, teardown — now completes in 5.5s wall clock, confirming the idle tail is gone.