### PR TITLE
Rebuild user_id foreign keys with ON DELETE CASCADE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run migration tests
+        run: pnpm run test:migrations
+
       - name: Build and run acceptance suite
         run: pnpm run test:acceptance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ migrations/           # Drizzle migrations
 | `pnpm run build` | Build for production |
 | `pnpm run preview` | Build and preview with Wrangler Pages locally |
 | `pnpm run test:acceptance` | Build, then run the acceptance suite against the built Worker on an isolated D1 (see `docs/acceptance-testing.md`) |
+| `pnpm run test:migrations` | Fast schema checks: apply `migrations/` to a scratch SQLite database and verify deletion semantics |
 | `pnpm run deploy` | Build and deploy to Cloudflare Pages |
 | `pnpm run cf-typegen` | Regenerate Cloudflare binding/runtime types |
 | `pnpm run db:generate` | Generate Drizzle migrations |

--- a/migrations/0006_user_fk_cascade.sql
+++ b/migrations/0006_user_fk_cascade.sql
@@ -1,0 +1,59 @@
+-- Rebuild books and reading_sessions so their user_id foreign keys gain
+-- ON DELETE CASCADE, matching src/lib/schema.ts (issue #291). SQLite cannot
+-- alter a foreign key in place; D1 keeps foreign keys enforced, so the
+-- rebuild defers enforcement until the migration's transaction commits.
+--
+-- Both copies happen before either drop, and the new reading_sessions
+-- references __new_books rather than books: cascade actions still fire under
+-- defer_foreign_keys, so dropping books must not be reachable from any table
+-- that already holds copied rows. The rename rewrites the reference back.
+PRAGMA defer_foreign_keys = true;--> statement-breakpoint
+CREATE TABLE `__new_books` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text NOT NULL,
+	`author` text NOT NULL,
+	`format` text NOT NULL,
+	`page_count` integer NOT NULL,
+	`isbn` text NOT NULL,
+	`author_sex` text NOT NULL,
+	`recommended` integer NOT NULL,
+	`genre` text NOT NULL,
+	`published_year` integer NOT NULL,
+	`publisher` text NOT NULL,
+	`date_acquired` text NOT NULL,
+	`date_removed` text,
+	`cost` real NOT NULL,
+	`starting_page` integer DEFAULT 0 NOT NULL,
+	`finished` integer DEFAULT false NOT NULL,
+	`user_id` text,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+INSERT INTO `__new_books` (`id`, `title`, `author`, `format`, `page_count`, `isbn`, `author_sex`, `recommended`, `genre`, `published_year`, `publisher`, `date_acquired`, `date_removed`, `cost`, `starting_page`, `finished`, `user_id`)
+SELECT `id`, `title`, `author`, `format`, `page_count`, `isbn`, `author_sex`, `recommended`, `genre`, `published_year`, `publisher`, `date_acquired`, `date_removed`, `cost`, `starting_page`, `finished`, `user_id` FROM `books`;--> statement-breakpoint
+CREATE TABLE `__new_reading_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`date` text NOT NULL,
+	`book_id` text NOT NULL,
+	`pages_read` integer NOT NULL,
+	`duration` integer NOT NULL,
+	`finished` integer NOT NULL,
+	`user_id` text,
+	FOREIGN KEY (`book_id`) REFERENCES `__new_books`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+INSERT INTO `__new_reading_sessions` (`id`, `date`, `book_id`, `pages_read`, `duration`, `finished`, `user_id`)
+SELECT `id`, `date`, `book_id`, `pages_read`, `duration`, `finished`, `user_id` FROM `reading_sessions`;--> statement-breakpoint
+DROP TABLE `reading_sessions`;--> statement-breakpoint
+DROP TABLE `books`;--> statement-breakpoint
+ALTER TABLE `__new_books` RENAME TO `books`;--> statement-breakpoint
+ALTER TABLE `__new_reading_sessions` RENAME TO `reading_sessions`;--> statement-breakpoint
+CREATE INDEX `books_user_id_idx` ON `books` (`user_id`);--> statement-breakpoint
+CREATE INDEX `books_title_author_idx` ON `books` (`title`,`author`);--> statement-breakpoint
+CREATE INDEX `books_finished_idx` ON `books` (`finished`);--> statement-breakpoint
+CREATE INDEX `books_genre_idx` ON `books` (`genre`);--> statement-breakpoint
+CREATE INDEX `books_user_title_id_idx` ON `books` (`user_id`,`title`,`id`);--> statement-breakpoint
+CREATE INDEX `books_user_date_acquired_id_idx` ON `books` (`user_id`,`date_acquired`,`id`);--> statement-breakpoint
+CREATE INDEX `reading_sessions_book_id_idx` ON `reading_sessions` (`book_id`);--> statement-breakpoint
+CREATE INDEX `reading_sessions_user_id_idx` ON `reading_sessions` (`user_id`);--> statement-breakpoint
+CREATE INDEX `reading_sessions_book_date_idx` ON `reading_sessions` (`book_id`,`date`);--> statement-breakpoint
+CREATE INDEX `reading_sessions_user_date_id_idx` ON `reading_sessions` (`user_id`,`date`,`id`);

--- a/migrations/meta/0006_snapshot.json
+++ b/migrations/meta/0006_snapshot.json
@@ -1,0 +1,731 @@
+{
+  "id": "fa71577d-4ad7-4aa2-acb8-a0883b829d46",
+  "prevId": "31fd1874-0e3b-4314-aaf1-c2f7d45a1c83",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_idx": {
+          "name": "account_provider_idx",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "books": {
+      "name": "books",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_sex": {
+          "name": "author_sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recommended": {
+          "name": "recommended",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_acquired": {
+          "name": "date_acquired",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_removed": {
+          "name": "date_removed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starting_page": {
+          "name": "starting_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finished": {
+          "name": "finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "books_user_id_idx": {
+          "name": "books_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "books_title_author_idx": {
+          "name": "books_title_author_idx",
+          "columns": [
+            "title",
+            "author"
+          ],
+          "isUnique": false
+        },
+        "books_finished_idx": {
+          "name": "books_finished_idx",
+          "columns": [
+            "finished"
+          ],
+          "isUnique": false
+        },
+        "books_genre_idx": {
+          "name": "books_genre_idx",
+          "columns": [
+            "genre"
+          ],
+          "isUnique": false
+        },
+        "books_user_title_id_idx": {
+          "name": "books_user_title_id_idx",
+          "columns": [
+            "user_id",
+            "title",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "books_user_date_acquired_id_idx": {
+          "name": "books_user_date_acquired_id_idx",
+          "columns": [
+            "user_id",
+            "date_acquired",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "books_user_id_user_id_fk": {
+          "name": "books_user_id_user_id_fk",
+          "tableFrom": "books",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reading_sessions": {
+      "name": "reading_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_read": {
+          "name": "pages_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished": {
+          "name": "finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reading_sessions_book_id_idx": {
+          "name": "reading_sessions_book_id_idx",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_user_id_idx": {
+          "name": "reading_sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_book_date_idx": {
+          "name": "reading_sessions_book_date_idx",
+          "columns": [
+            "book_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_user_date_id_idx": {
+          "name": "reading_sessions_user_date_id_idx",
+          "columns": [
+            "user_id",
+            "date",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reading_sessions_book_id_books_id_fk": {
+          "name": "reading_sessions_book_id_books_id_fk",
+          "tableFrom": "reading_sessions",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "tableTo": "books",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "reading_sessions_user_id_user_id_fk": {
+          "name": "reading_sessions_user_id_user_id_fk",
+          "tableFrom": "reading_sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1746465808173,
       "tag": "0005_jazzy_tattoo",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1787491353874,
+      "tag": "0006_user_fk_cascade",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "astro check && astro build",
     "preview": "astro build && astro preview",
     "test:acceptance": "node scripts/acceptance.mjs",
+    "test:migrations": "vitest run --project migrations",
     "astro": "astro",
     "deploy": "astro build && wrangler deploy",
     "cf-typegen": "wrangler types",

--- a/scripts/acceptance.mjs
+++ b/scripts/acceptance.mjs
@@ -194,7 +194,7 @@ try {
   await waitForReady(`${baseURL}/login`, 90_000);
   console.log("[acceptance] Worker is ready, running acceptance suite");
 
-  await run("pnpm", ["exec", "vitest", "run"], {
+  await run("pnpm", ["exec", "vitest", "run", "--project", "acceptance"], {
     env: {
       ...process.env,
       ACCEPTANCE_BASE_URL: baseURL,

--- a/tests/acceptance/helpers.ts
+++ b/tests/acceptance/helpers.ts
@@ -147,19 +147,11 @@ export function deleteFixtures(fixtures: Fixture[]): void {
   }
   const db = openDatabase();
   try {
-    // The deployed schema's user_id foreign keys predate ON DELETE CASCADE,
-    // so dependent rows are removed explicitly, leaves first.
-    const statements = [
-      'DELETE FROM reading_sessions WHERE user_id IN (SELECT id FROM user WHERE email = ?)',
-      'DELETE FROM books WHERE user_id IN (SELECT id FROM user WHERE email = ?)',
-      'DELETE FROM session WHERE user_id IN (SELECT id FROM user WHERE email = ?)',
-      'DELETE FROM account WHERE user_id IN (SELECT id FROM user WHERE email = ?)',
-      'DELETE FROM user WHERE email = ?',
-    ].map((sql) => db.prepare(sql));
+    // Every user_id foreign key carries ON DELETE CASCADE (since migration
+    // 0006), so deleting the user removes the dependent rows too.
+    const statement = db.prepare('DELETE FROM user WHERE email = ?');
     for (const fixture of fixtures) {
-      for (const statement of statements) {
-        statement.run(fixture.email);
-      }
+      statement.run(fixture.email);
     }
   } finally {
     db.close();

--- a/tests/migrations/reader-deletion.test.ts
+++ b/tests/migrations/reader-deletion.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Verifies the deletion semantics of the migrated schema itself (issue #291):
+ * `books.user_id` and `reading_sessions.user_id` must cascade when a Reader's
+ * `user` row is deleted, as `src/lib/schema.ts` declares.
+ *
+ * The suite applies the real migration files to a scratch database the way
+ * D1 does: foreign keys always enforced, each migration file executed as a
+ * single transaction.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
+
+const migrationsDir = path.resolve(import.meta.dirname, '../../migrations');
+
+function migrationTags(): string[] {
+  const journal = JSON.parse(
+    readFileSync(path.join(migrationsDir, 'meta', '_journal.json'), 'utf8')
+  ) as { entries: { tag: string }[] };
+  return journal.entries.map((entry) => entry.tag);
+}
+
+function applyMigration(db: DatabaseSync, tag: string): void {
+  const sql = readFileSync(path.join(migrationsDir, `${tag}.sql`), 'utf8');
+  db.exec('BEGIN');
+  try {
+    for (const statement of sql.split('--> statement-breakpoint')) {
+      if (statement.trim()) {
+        db.exec(statement);
+      }
+    }
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+}
+
+function openScratchDatabase(): DatabaseSync {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  return db;
+}
+
+function openMigratedDatabase(): DatabaseSync {
+  const db = openScratchDatabase();
+  for (const tag of migrationTags()) {
+    applyMigration(db, tag);
+  }
+  return db;
+}
+
+function insertUser(db: DatabaseSync, id: string): void {
+  db.prepare(
+    `INSERT INTO user (id, name, email, email_verified, created_at, updated_at)
+     VALUES (?, ?, ?, 1, 0, 0)`
+  ).run(id, id, `${id}@migrations.invalid`);
+}
+
+function insertBook(db: DatabaseSync, id: string, userId: string | null): void {
+  db.prepare(
+    `INSERT INTO books (
+       id, title, author, format, page_count, isbn, author_sex, recommended,
+       genre, published_year, publisher, date_acquired, date_removed, cost,
+       starting_page, finished, user_id
+     ) VALUES (?, 'Title', 'Author', 'physical', 100, '0000000000', 'Unknown',
+       0, 'Fiction', 2020, 'Publisher', '2026-01-01', NULL, 9.99, 0, 0, ?)`
+  ).run(id, userId);
+}
+
+function insertReadingSession(
+  db: DatabaseSync,
+  id: string,
+  bookId: string,
+  userId: string | null
+): void {
+  db.prepare(
+    `INSERT INTO reading_sessions (id, date, book_id, pages_read, duration, finished, user_id)
+     VALUES (?, '2026-01-02', ?, 10, 600, 0, ?)`
+  ).run(id, bookId, userId);
+}
+
+function count(db: DatabaseSync, table: string, id: string): number {
+  const row = db
+    .prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE id = ?`)
+    .get(id) as { n: number };
+  return Number(row.n);
+}
+
+describe('the user_id cascade rebuild (0006)', () => {
+  const REBUILD_TAG = '0006_user_fk_cascade';
+
+  it('preserves existing rows and indexes', () => {
+    const db = openScratchDatabase();
+    try {
+      const tags = migrationTags();
+      const rebuildIndex = tags.indexOf(REBUILD_TAG);
+      expect(rebuildIndex).toBeGreaterThan(0);
+      for (const tag of tags.slice(0, rebuildIndex)) {
+        applyMigration(db, tag);
+      }
+
+      insertUser(db, 'reader');
+      insertBook(db, 'book', 'reader');
+      insertBook(db, 'legacy-book', null);
+      insertReadingSession(db, 'session', 'book', 'reader');
+      const before = {
+        books: db.prepare('SELECT * FROM books ORDER BY id').all(),
+        sessions: db.prepare('SELECT * FROM reading_sessions ORDER BY id').all(),
+      };
+
+      for (const tag of tags.slice(rebuildIndex)) {
+        applyMigration(db, tag);
+      }
+
+      expect(db.prepare('SELECT * FROM books ORDER BY id').all()).toEqual(before.books);
+      expect(db.prepare('SELECT * FROM reading_sessions ORDER BY id').all()).toEqual(
+        before.sessions
+      );
+      const indexes = db
+        .prepare(
+          `SELECT name FROM sqlite_master
+           WHERE type = 'index' AND tbl_name IN ('books', 'reading_sessions')
+           AND name NOT LIKE 'sqlite_%' ORDER BY name`
+        )
+        .all()
+        .map((row) => (row as { name: string }).name);
+      expect(indexes).toEqual([
+        'books_finished_idx',
+        'books_genre_idx',
+        'books_title_author_idx',
+        'books_user_date_acquired_id_idx',
+        'books_user_id_idx',
+        'books_user_title_id_idx',
+        'reading_sessions_book_date_idx',
+        'reading_sessions_book_id_idx',
+        'reading_sessions_user_date_id_idx',
+        'reading_sessions_user_id_idx',
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('Reader deletion', () => {
+  it('cascades to the `books` and `reading_sessions` rows the Reader owns', () => {
+    const db = openMigratedDatabase();
+    try {
+      insertUser(db, 'reader');
+      insertBook(db, 'book', 'reader');
+      insertReadingSession(db, 'session', 'book', 'reader');
+
+      db.prepare('DELETE FROM user WHERE id = ?').run('reader');
+
+      expect(count(db, 'books', 'book')).toBe(0);
+      expect(count(db, 'reading_sessions', 'session')).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('leaves other Readers and legacy unowned rows intact', () => {
+    const db = openMigratedDatabase();
+    try {
+      insertUser(db, 'departing');
+      insertBook(db, 'departing-book', 'departing');
+      insertUser(db, 'staying');
+      insertBook(db, 'staying-book', 'staying');
+      insertReadingSession(db, 'staying-session', 'staying-book', 'staying');
+      insertBook(db, 'legacy-book', null);
+      insertReadingSession(db, 'legacy-session', 'legacy-book', null);
+
+      db.prepare('DELETE FROM user WHERE id = ?').run('departing');
+
+      expect(count(db, 'books', 'staying-book')).toBe(1);
+      expect(count(db, 'reading_sessions', 'staying-session')).toBe(1);
+      expect(count(db, 'books', 'legacy-book')).toBe(1);
+      expect(count(db, 'reading_sessions', 'legacy-session')).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,11 +2,27 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/acceptance/**/*.test.ts'],
-    // The suite shares one worker and one D1 database; run files sequentially
-    // so fixture setup and cleanup stay deterministic.
-    fileParallelism: false,
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
+    projects: [
+      {
+        test: {
+          // Fast schema/migration checks against a scratch SQLite database;
+          // needs no build or running worker.
+          name: 'migrations',
+          include: ['tests/migrations/**/*.test.ts'],
+        },
+      },
+      {
+        test: {
+          // Runs against a built worker; invoke via `pnpm run test:acceptance`.
+          name: 'acceptance',
+          include: ['tests/acceptance/**/*.test.ts'],
+          // The suite shares one worker and one D1 database; run files
+          // sequentially so fixture setup and cleanup stay deterministic.
+          fileParallelism: false,
+          testTimeout: 30_000,
+          hookTimeout: 30_000,
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
Fixes #291

## What

- Migration `0006_user_fk_cascade.sql` rebuilds `books` and `reading_sessions` so their `user_id` foreign keys gain `ON DELETE CASCADE`, matching what `src/lib/schema.ts` (and drizzle's snapshots) already declared. Direction chosen per ADR 0006: these rows are a Reader's private data, and #288 (account erasure) needs exactly these deletion semantics.
- New fast test suite `tests/migrations/reader-deletion.test.ts` replays the real migration files against a scratch `node:sqlite` database the way D1 applies them (foreign keys always enforced, one transaction per file) and verifies the cascade, that other Readers' and legacy unowned (`user_id IS NULL`) rows survive, and that the rebuild preserves every row value and all ten indexes.
- Acceptance fixture cleanup (`tests/acceptance/helpers.ts`) now deletes just the `user` row and relies on the cascade.
- Supporting wiring: vitest split into `migrations`/`acceptance` projects, `pnpm run test:migrations`, a CI step before the acceptance job, and an AGENTS.md command-table row.

## Migration subtlety

Cascade *actions* still fire under `PRAGMA defer_foreign_keys` (the red test caught this): a naive rebuild order let `DROP TABLE books` cascade into the old `reading_sessions` before its rows were copied. The migration therefore copies both tables before dropping either, and the new sessions table references `__new_books` so the drop can't reach it; the `ALTER TABLE ... RENAME` rewrites the reference back to `books`.

## Verification

- `pnpm run test:migrations` 3/3 (was red with the exact `FOREIGN KEY constraint failed` from the issue before the migration existed)
- `pnpm run test:acceptance` 10/10, which also applies migration 0006 under wrangler's real local D1
- `astro check` clean

## After merge

The deployed databases still need `pnpm run db:migrate:preview` / `pnpm run db:migrate:prod`.