### PR TITLE
Create and search sparse Works

### DIFF
--- a/migrations/0007_create_works.sql
+++ b/migrations/0007_create_works.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `works` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text NOT NULL,
+	`first_publication_date` text
+);
+--> statement-breakpoint
+CREATE INDEX `works_title_idx` ON `works` (`title`);

--- a/migrations/0008_known_lila_cheney.sql
+++ b/migrations/0008_known_lila_cheney.sql
@@ -1,6 +1,9 @@
--- Persist a normalized title key so catalog search can filter in D1.
+-- Persist a searchable title key so catalog search can filter in D1.
 -- SQLite requires a default when adding a NOT NULL column to a table that
--- may already have rows; new writes always set title_search from the title.
+-- may already have rows. D1 SQL cannot NFC-normalize or Unicode-fold, so this
+-- backfill uses ASCII `lower(title)` only. Runtime writes set title_search
+-- with NFC + JavaScript toLowerCase(). 0007 and 0008 ship together, so a
+-- single deploy backfills an empty table.
 ALTER TABLE `works` ADD `title_search` text DEFAULT '' NOT NULL;--> statement-breakpoint
 UPDATE `works` SET `title_search` = lower(`title`) WHERE `title_search` = '';--> statement-breakpoint
 CREATE INDEX `works_title_search_idx` ON `works` (`title_search`);

--- a/migrations/0008_known_lila_cheney.sql
+++ b/migrations/0008_known_lila_cheney.sql
@@ -1,0 +1,6 @@
+-- Persist a normalized title key so catalog search can filter in D1.
+-- SQLite requires a default when adding a NOT NULL column to a table that
+-- may already have rows; new writes always set title_search from the title.
+ALTER TABLE `works` ADD `title_search` text DEFAULT '' NOT NULL;--> statement-breakpoint
+UPDATE `works` SET `title_search` = lower(`title`) WHERE `title_search` = '';--> statement-breakpoint
+CREATE INDEX `works_title_search_idx` ON `works` (`title_search`);

--- a/migrations/0008_known_lila_cheney.sql
+++ b/migrations/0008_known_lila_cheney.sql
@@ -2,7 +2,7 @@
 -- SQLite requires a default when adding a NOT NULL column to a table that
 -- may already have rows. D1 SQL cannot NFC-normalize or Unicode-fold, so this
 -- backfill uses ASCII `lower(title)` only. Runtime writes set title_search
--- with NFC + JavaScript toLowerCase(). 0007 and 0008 ship together, so a
+-- with NFC + JavaScript toLowerCase() then ς→σ. 0007 and 0008 ship together, so a
 -- single deploy backfills an empty table.
 ALTER TABLE `works` ADD `title_search` text DEFAULT '' NOT NULL;--> statement-breakpoint
 UPDATE `works` SET `title_search` = lower(`title`) WHERE `title_search` = '';--> statement-breakpoint

--- a/migrations/meta/0007_snapshot.json
+++ b/migrations/meta/0007_snapshot.json
@@ -1,0 +1,770 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c8df81cc-5e27-42f2-8482-9ea3ac1b14c1",
+  "prevId": "fa71577d-4ad7-4aa2-acb8-a0883b829d46",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_idx": {
+          "name": "account_provider_idx",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "books": {
+      "name": "books",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_sex": {
+          "name": "author_sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recommended": {
+          "name": "recommended",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_acquired": {
+          "name": "date_acquired",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_removed": {
+          "name": "date_removed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starting_page": {
+          "name": "starting_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finished": {
+          "name": "finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "books_user_id_idx": {
+          "name": "books_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "books_title_author_idx": {
+          "name": "books_title_author_idx",
+          "columns": [
+            "title",
+            "author"
+          ],
+          "isUnique": false
+        },
+        "books_finished_idx": {
+          "name": "books_finished_idx",
+          "columns": [
+            "finished"
+          ],
+          "isUnique": false
+        },
+        "books_genre_idx": {
+          "name": "books_genre_idx",
+          "columns": [
+            "genre"
+          ],
+          "isUnique": false
+        },
+        "books_user_title_id_idx": {
+          "name": "books_user_title_id_idx",
+          "columns": [
+            "user_id",
+            "title",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "books_user_date_acquired_id_idx": {
+          "name": "books_user_date_acquired_id_idx",
+          "columns": [
+            "user_id",
+            "date_acquired",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "books_user_id_user_id_fk": {
+          "name": "books_user_id_user_id_fk",
+          "tableFrom": "books",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reading_sessions": {
+      "name": "reading_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_read": {
+          "name": "pages_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished": {
+          "name": "finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reading_sessions_book_id_idx": {
+          "name": "reading_sessions_book_id_idx",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_user_id_idx": {
+          "name": "reading_sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_book_date_idx": {
+          "name": "reading_sessions_book_date_idx",
+          "columns": [
+            "book_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_user_date_id_idx": {
+          "name": "reading_sessions_user_date_id_idx",
+          "columns": [
+            "user_id",
+            "date",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reading_sessions_book_id_books_id_fk": {
+          "name": "reading_sessions_book_id_books_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_user_id_user_id_fk": {
+          "name": "reading_sessions_user_id_user_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "works": {
+      "name": "works",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "works_title_idx": {
+          "name": "works_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/0008_snapshot.json
+++ b/migrations/meta/0008_snapshot.json
@@ -1,0 +1,784 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "790ab1c3-c905-41ec-a26b-2fe9a5e6bb86",
+  "prevId": "c8df81cc-5e27-42f2-8482-9ea3ac1b14c1",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_idx": {
+          "name": "account_provider_idx",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "books": {
+      "name": "books",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_sex": {
+          "name": "author_sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recommended": {
+          "name": "recommended",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_acquired": {
+          "name": "date_acquired",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_removed": {
+          "name": "date_removed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starting_page": {
+          "name": "starting_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finished": {
+          "name": "finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "books_user_id_idx": {
+          "name": "books_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "books_title_author_idx": {
+          "name": "books_title_author_idx",
+          "columns": [
+            "title",
+            "author"
+          ],
+          "isUnique": false
+        },
+        "books_finished_idx": {
+          "name": "books_finished_idx",
+          "columns": [
+            "finished"
+          ],
+          "isUnique": false
+        },
+        "books_genre_idx": {
+          "name": "books_genre_idx",
+          "columns": [
+            "genre"
+          ],
+          "isUnique": false
+        },
+        "books_user_title_id_idx": {
+          "name": "books_user_title_id_idx",
+          "columns": [
+            "user_id",
+            "title",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "books_user_date_acquired_id_idx": {
+          "name": "books_user_date_acquired_id_idx",
+          "columns": [
+            "user_id",
+            "date_acquired",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "books_user_id_user_id_fk": {
+          "name": "books_user_id_user_id_fk",
+          "tableFrom": "books",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reading_sessions": {
+      "name": "reading_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_read": {
+          "name": "pages_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished": {
+          "name": "finished",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reading_sessions_book_id_idx": {
+          "name": "reading_sessions_book_id_idx",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_user_id_idx": {
+          "name": "reading_sessions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_book_date_idx": {
+          "name": "reading_sessions_book_date_idx",
+          "columns": [
+            "book_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "reading_sessions_user_date_id_idx": {
+          "name": "reading_sessions_user_date_id_idx",
+          "columns": [
+            "user_id",
+            "date",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reading_sessions_book_id_books_id_fk": {
+          "name": "reading_sessions_book_id_books_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_user_id_user_id_fk": {
+          "name": "reading_sessions_user_id_user_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "works": {
+      "name": "works",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title_search": {
+          "name": "title_search",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_publication_date": {
+          "name": "first_publication_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "works_title_idx": {
+          "name": "works_title_idx",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "works_title_search_idx": {
+          "name": "works_title_search_idx",
+          "columns": [
+            "title_search"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788715446245,
       "tag": "0007_create_works",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1788725016479,
+      "tag": "0008_known_lila_cheney",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1787491353874,
       "tag": "0006_user_fk_cascade",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1788715446245,
+      "tag": "0007_create_works",
+      "breakpoints": true
     }
   ]
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -101,6 +101,12 @@ if (!isLoggedIn) {
                 </li>
                 <li>
                   <a
+                    href="/works"
+                    class="hover:text-indigo-400 transition-colors">Catalog</a
+                  >
+                </li>
+                <li>
+                  <a
                     href="/books"
                     class="hover:text-indigo-400 transition-colors">Library</a
                   >

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,7 +1,5 @@
-import { eq, sql, asc } from 'drizzle-orm';
-import { v4 as uuidv4 } from 'uuid';
-import { getDbClient } from './db-client';
-import { works, type Work } from './schema';
+import { insertWork } from './db';
+import type { Work } from './schema';
 
 export class CatalogValidationError extends Error {
   constructor(message: string) {
@@ -70,32 +68,11 @@ export async function createWork(
   input: { title?: unknown; firstPublicationDate?: unknown },
   env: Env
 ): Promise<Work> {
-  const work: Work = {
-    id: uuidv4(),
-    title: parseTitle(input.title),
-    firstPublicationDate: parseFirstPublicationDate(input.firstPublicationDate),
-  };
-
-  const db = getDbClient(env);
-  await db.insert(works).values(work);
-  return work;
-}
-
-export async function getWorkById(id: string, env: Env): Promise<Work | undefined> {
-  const db = getDbClient(env);
-  const results = await db.select().from(works).where(eq(works.id, id)).limit(1);
-  return results[0];
-}
-
-export async function searchWorks(query: string, env: Env): Promise<Work[]> {
-  const db = getDbClient(env);
-  const needle = query.trim().toLowerCase();
-  if (!needle) {
-    return db.select().from(works).orderBy(asc(works.title));
-  }
-  return db
-    .select()
-    .from(works)
-    .where(sql`instr(lower(${works.title}), ${needle}) > 0`)
-    .orderBy(asc(works.title));
+  return insertWork(
+    {
+      title: parseTitle(input.title),
+      firstPublicationDate: parseFirstPublicationDate(input.firstPublicationDate),
+    },
+    env
+  );
 }

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,0 +1,101 @@
+import { eq, sql, asc } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { getDbClient } from './db-client';
+import { works, type Work } from './schema';
+
+export class CatalogValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CatalogValidationError';
+  }
+}
+
+export interface WorkResource {
+  id: string;
+  title: string;
+  firstPublicationDate: string | null;
+}
+
+export function toWorkResource(work: Work): WorkResource {
+  return {
+    id: work.id,
+    title: work.title,
+    firstPublicationDate: work.firstPublicationDate ?? null,
+  };
+}
+
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function parseTitle(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new CatalogValidationError('Title is required');
+  }
+  const title = value.trim();
+  if (!title) {
+    throw new CatalogValidationError('Title is required');
+  }
+  return title;
+}
+
+function parseFirstPublicationDate(value: unknown): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    throw new CatalogValidationError(
+      'First publication date must be an ISO date (YYYY-MM-DD) or unknown'
+    );
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const match = ISO_DATE.exec(trimmed);
+  if (!match) {
+    throw new CatalogValidationError(
+      'First publication date must be an ISO date (YYYY-MM-DD) or unknown'
+    );
+  }
+  const iso = `${trimmed}T00:00:00.000Z`;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== trimmed) {
+    throw new CatalogValidationError(
+      'First publication date must be an ISO date (YYYY-MM-DD) or unknown'
+    );
+  }
+  return trimmed;
+}
+
+export async function createWork(
+  input: { title?: unknown; firstPublicationDate?: unknown },
+  env: Env
+): Promise<Work> {
+  const work: Work = {
+    id: uuidv4(),
+    title: parseTitle(input.title),
+    firstPublicationDate: parseFirstPublicationDate(input.firstPublicationDate),
+  };
+
+  const db = getDbClient(env);
+  await db.insert(works).values(work);
+  return work;
+}
+
+export async function getWorkById(id: string, env: Env): Promise<Work | undefined> {
+  const db = getDbClient(env);
+  const results = await db.select().from(works).where(eq(works.id, id)).limit(1);
+  return results[0];
+}
+
+export async function searchWorks(query: string, env: Env): Promise<Work[]> {
+  const db = getDbClient(env);
+  const needle = query.trim().toLowerCase();
+  if (!needle) {
+    return db.select().from(works).orderBy(asc(works.title));
+  }
+  return db
+    .select()
+    .from(works)
+    .where(sql`instr(lower(${works.title}), ${needle}) > 0`)
+    .orderBy(asc(works.title));
+}

--- a/src/lib/db-client.ts
+++ b/src/lib/db-client.ts
@@ -1,5 +1,4 @@
 import { drizzle } from 'drizzle-orm/d1';
-import { drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
 import * as schema from './schema';
 
 // Singleton database client
@@ -11,7 +10,7 @@ let db: ReturnType<typeof createDrizzleClient>;
  * @param env - The environment object containing the D1 database binding.
  * @returns A Drizzle ORM client instance connected to the D1 database.
  */
-export function createDrizzleClient(env: Env): ReturnType<typeof drizzle> | ReturnType<typeof drizzleSqlite> {
+export function createDrizzleClient(env: Env): ReturnType<typeof drizzle> {
   console.log('Using D1 database in Cloudflare environment');
   // Use D1 database in Cloudflare environment
   return drizzle(env.DB, { schema });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,10 +10,6 @@ function foldSearchText(value: string): string {
   return value.normalize('NFC').toLowerCase();
 }
 
-function likeContainsPattern(value: string): string {
-  return `%${value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_')}%`;
-}
-
 /**
  * Inserts a Work and returns the persisted record with a generated ID.
  *
@@ -55,8 +51,10 @@ export async function getWorkById(id: string, env: Env): Promise<Work | undefine
  * Searches locally stored Works by title substring.
  *
  * Matching uses the persisted NFC-lowercase `titleSearch` key so D1 can filter
- * without SQLite `lower()` or loading the full catalog into the Worker. An
- * empty query returns a title-ordered page rather than every row.
+ * without SQLite `lower()` or loading the full catalog into the Worker. D1
+ * rejects LIKE patterns longer than 50 characters, so substring matching uses
+ * `instr` instead. An empty query returns a title-ordered page rather than
+ * every row.
  */
 export async function searchWorks(query: string, env: Env): Promise<Work[]> {
   try {
@@ -73,7 +71,7 @@ export async function searchWorks(query: string, env: Env): Promise<Work[]> {
     return await db
       .select()
       .from(works)
-      .where(sql`${works.titleSearch} LIKE ${likeContainsPattern(needle)} ESCAPE '\\'`)
+      .where(sql`instr(${works.titleSearch}, ${needle}) > 0`)
       .orderBy(asc(works.title))
       .limit(WORK_SEARCH_LIMIT);
   } catch (error) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4,17 +4,27 @@ import { getDbClient } from './db-client';
 import { books, readingSessions, works, type Book, type ReadingSession, type Work } from './schema';
 import { v4 as uuidv4 } from 'uuid';
 
+const WORK_SEARCH_LIMIT = 50;
+
 function foldSearchText(value: string): string {
   return value.normalize('NFC').toLowerCase();
 }
 
+function likeContainsPattern(value: string): string {
+  return `%${value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_')}%`;
+}
+
 /**
  * Inserts a Work and returns the persisted record with a generated ID.
+ *
+ * Persists `titleSearch` as the NFC-normalized, lowercased title so catalog
+ * search can filter in D1 without loading the full table.
  */
-export async function insertWork(workData: Omit<Work, 'id'>, env: Env): Promise<Work> {
+export async function insertWork(workData: Omit<Work, 'id' | 'titleSearch'>, env: Env): Promise<Work> {
   const newWork: Work = {
     ...workData,
     id: uuidv4(),
+    titleSearch: foldSearchText(workData.title),
   };
 
   try {
@@ -44,19 +54,28 @@ export async function getWorkById(id: string, env: Env): Promise<Work | undefine
 /**
  * Searches locally stored Works by title substring.
  *
- * Matching lowercases and NFC-normalizes both the query and stored titles in
- * JavaScript so non-ASCII letters such as É fold the same way on both sides.
- * An empty query returns every Work, ordered by title.
+ * Matching uses the persisted NFC-lowercase `titleSearch` key so D1 can filter
+ * without SQLite `lower()` or loading the full catalog into the Worker. An
+ * empty query returns a title-ordered page rather than every row.
  */
 export async function searchWorks(query: string, env: Env): Promise<Work[]> {
   try {
     const db = getDbClient(env);
-    const rows = await db.select().from(works).orderBy(asc(works.title));
     const needle = foldSearchText(query.trim());
     if (!needle) {
-      return rows;
+      return await db
+        .select()
+        .from(works)
+        .orderBy(asc(works.title))
+        .limit(WORK_SEARCH_LIMIT);
     }
-    return rows.filter((work) => foldSearchText(work.title).includes(needle));
+
+    return await db
+      .select()
+      .from(works)
+      .where(sql`${works.titleSearch} LIKE ${likeContainsPattern(needle)} ESCAPE '\\'`)
+      .orderBy(asc(works.title))
+      .limit(WORK_SEARCH_LIMIT);
   } catch (error) {
     console.error('Error searching works:', error);
     throw new Error(`Failed to search works: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,14 +7,17 @@ import { v4 as uuidv4 } from 'uuid';
 const WORK_SEARCH_LIMIT = 50;
 
 function foldSearchText(value: string): string {
-  return value.normalize('NFC').toLowerCase();
+  // toLowerCase() maps Greek final sigma (ΟΣ → ος) but not a lone Σ → σ.
+  // Fold ς → σ so stored titles and queries share one substring key.
+  return value.normalize('NFC').toLowerCase().replaceAll('ς', 'σ');
 }
 
 /**
  * Inserts a Work and returns the persisted record with a generated ID.
  *
- * Persists `titleSearch` as the NFC-normalized, lowercased title so catalog
- * search can filter in D1 without loading the full table.
+ * Persists `titleSearch` as the NFC-normalized, lowercased title (with final
+ * sigma folded to σ) so catalog search can filter in D1 without loading the
+ * full table.
  */
 export async function insertWork(workData: Omit<Work, 'id' | 'titleSearch'>, env: Env): Promise<Work> {
   const newWork: Work = {
@@ -50,12 +53,12 @@ export async function getWorkById(id: string, env: Env): Promise<Work | undefine
 /**
  * Searches locally stored Works by title substring.
  *
- * Matching uses the persisted NFC-lowercase `titleSearch` key so D1 can filter
- * without SQLite `lower()` or loading the full catalog into the Worker. D1
- * rejects LIKE patterns longer than 50 characters, so substring matching uses
- * `instr` instead of `LIKE`. A btree cannot serve substring `instr`; FTS5 is
- * follow-on. An empty query returns a title-ordered page rather than every
- * row. Results are always bounded with LIMIT 50.
+ * Matching uses the persisted NFC-lowercase `titleSearch` key (final sigma
+ * folded to σ) so D1 can filter without SQLite `lower()` or loading the full
+ * catalog into the Worker. D1 rejects LIKE patterns longer than 50 characters,
+ * so substring matching uses `instr` instead of `LIKE`. A btree cannot serve
+ * substring `instr`; FTS5 is follow-on. An empty query returns a title-ordered
+ * page rather than every row. Results are always bounded with LIMIT 50.
  */
 export async function searchWorks(query: string, env: Env): Promise<Work[]> {
   try {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -53,8 +53,9 @@ export async function getWorkById(id: string, env: Env): Promise<Work | undefine
  * Matching uses the persisted NFC-lowercase `titleSearch` key so D1 can filter
  * without SQLite `lower()` or loading the full catalog into the Worker. D1
  * rejects LIKE patterns longer than 50 characters, so substring matching uses
- * `instr` instead. An empty query returns a title-ordered page rather than
- * every row.
+ * `instr` instead of `LIKE`. A btree cannot serve substring `instr`; FTS5 is
+ * follow-on. An empty query returns a title-ordered page rather than every
+ * row. Results are always bounded with LIMIT 50.
  */
 export async function searchWorks(query: string, env: Env): Promise<Work[]> {
   try {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,8 +1,67 @@
 // Types for our book and reading session data
-import { eq, and, sql, inArray } from 'drizzle-orm';
+import { eq, and, sql, inArray, asc } from 'drizzle-orm';
 import { getDbClient } from './db-client';
-import { books, readingSessions, type Book, type ReadingSession } from './schema';
+import { books, readingSessions, works, type Book, type ReadingSession, type Work } from './schema';
 import { v4 as uuidv4 } from 'uuid';
+
+function foldSearchText(value: string): string {
+  return value.normalize('NFC').toLowerCase();
+}
+
+/**
+ * Inserts a Work and returns the persisted record with a generated ID.
+ */
+export async function insertWork(workData: Omit<Work, 'id'>, env: Env): Promise<Work> {
+  const newWork: Work = {
+    ...workData,
+    id: uuidv4(),
+  };
+
+  try {
+    const db = getDbClient(env);
+    await db.insert(works).values(newWork);
+    return newWork;
+  } catch (error) {
+    console.error('Error adding work:', error);
+    throw new Error(`Failed to add work: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+/**
+ * Retrieves a Work by its unique ID.
+ */
+export async function getWorkById(id: string, env: Env): Promise<Work | undefined> {
+  try {
+    const db = getDbClient(env);
+    const results = await db.select().from(works).where(eq(works.id, id)).limit(1);
+    return results[0];
+  } catch (error) {
+    console.error('Error getting work by ID:', error);
+    throw new Error(`Failed to retrieve work: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+/**
+ * Searches locally stored Works by title substring.
+ *
+ * Matching lowercases and NFC-normalizes both the query and stored titles in
+ * JavaScript so non-ASCII letters such as É fold the same way on both sides.
+ * An empty query returns every Work, ordered by title.
+ */
+export async function searchWorks(query: string, env: Env): Promise<Work[]> {
+  try {
+    const db = getDbClient(env);
+    const rows = await db.select().from(works).orderBy(asc(works.title));
+    const needle = foldSearchText(query.trim());
+    if (!needle) {
+      return rows;
+    }
+    return rows.filter((work) => foldSearchText(work.title).includes(needle));
+  } catch (error) {
+    console.error('Error searching works:', error);
+    throw new Error(`Failed to search works: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
 
 /**
  * Calculates reading progress statistics for a book based on its reading sessions.

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,5 +1,13 @@
 import { sqliteTable, text, integer, real, index } from 'drizzle-orm/sqlite-core';
 
+export const works = sqliteTable('works', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  firstPublicationDate: text('first_publication_date'),
+}, (table) => [
+  index('works_title_idx').on(table.title),
+]);
+
 export const books = sqliteTable('books', {
   id: text('id').primaryKey(),
   title: text('title').notNull(),
@@ -105,6 +113,9 @@ export const verification = sqliteTable("verification", {
   index('verification_identifier_idx').on(table.identifier),
   index('verification_expires_at_idx').on(table.expiresAt),
 ]);
+
+export type Work = typeof works.$inferSelect;
+export type NewWork = typeof works.$inferInsert;
 
 // Types for our book and reading session data
 export type Book = typeof books.$inferSelect;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -3,9 +3,11 @@ import { sqliteTable, text, integer, real, index } from 'drizzle-orm/sqlite-core
 export const works = sqliteTable('works', {
   id: text('id').primaryKey(),
   title: text('title').notNull(),
+  titleSearch: text('title_search').notNull(),
   firstPublicationDate: text('first_publication_date'),
 }, (table) => [
   index('works_title_idx').on(table.title),
+  index('works_title_search_idx').on(table.titleSearch),
 ]);
 
 export const books = sqliteTable('books', {

--- a/src/pages/api/works.ts
+++ b/src/pages/api/works.ts
@@ -3,9 +3,9 @@ import type { APIRoute } from 'astro';
 import {
   CatalogValidationError,
   createWork,
-  searchWorks,
   toWorkResource,
 } from '../../lib/catalog';
+import { searchWorks } from '../../lib/db';
 import {
   getAuthenticatedUserId,
   jsonResponse,

--- a/src/pages/api/works.ts
+++ b/src/pages/api/works.ts
@@ -1,0 +1,58 @@
+import { env } from 'cloudflare:workers';
+import type { APIRoute } from 'astro';
+import {
+  CatalogValidationError,
+  createWork,
+  searchWorks,
+  toWorkResource,
+} from '../../lib/catalog';
+import {
+  getAuthenticatedUserId,
+  jsonResponse,
+  unauthorizedResponse,
+} from '../../lib/api-auth';
+
+export const GET: APIRoute = async ({ url, locals }) => {
+  if (!getAuthenticatedUserId(locals)) {
+    return unauthorizedResponse();
+  }
+
+  const query = url.searchParams.get('q') ?? '';
+  const found = await searchWorks(query, env);
+  return jsonResponse({ works: found.map(toWorkResource) });
+};
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  if (!getAuthenticatedUserId(locals)) {
+    return unauthorizedResponse();
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid work data' }, 400);
+  }
+
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return jsonResponse({ error: 'Invalid work data' }, 400);
+  }
+
+  const payload = body as Record<string, unknown>;
+  try {
+    const work = await createWork(
+      {
+        title: payload.title,
+        firstPublicationDate: payload.firstPublicationDate,
+      },
+      env
+    );
+    return jsonResponse(toWorkResource(work), 201);
+  } catch (error) {
+    if (error instanceof CatalogValidationError) {
+      return jsonResponse({ error: error.message }, 400);
+    }
+    console.error('Error creating Work:', error);
+    return jsonResponse({ error: 'Failed to create Work' }, 500);
+  }
+};

--- a/src/pages/api/works/[id].ts
+++ b/src/pages/api/works/[id].ts
@@ -1,6 +1,7 @@
 import { env } from 'cloudflare:workers';
 import type { APIRoute } from 'astro';
-import { getWorkById, toWorkResource } from '../../../lib/catalog';
+import { toWorkResource } from '../../../lib/catalog';
+import { getWorkById } from '../../../lib/db';
 import {
   getAuthenticatedUserId,
   jsonResponse,

--- a/src/pages/api/works/[id].ts
+++ b/src/pages/api/works/[id].ts
@@ -1,0 +1,26 @@
+import { env } from 'cloudflare:workers';
+import type { APIRoute } from 'astro';
+import { getWorkById, toWorkResource } from '../../../lib/catalog';
+import {
+  getAuthenticatedUserId,
+  jsonResponse,
+  unauthorizedResponse,
+} from '../../../lib/api-auth';
+
+export const GET: APIRoute = async ({ params, locals }) => {
+  if (!getAuthenticatedUserId(locals)) {
+    return unauthorizedResponse();
+  }
+
+  const { id } = params;
+  if (!id) {
+    return jsonResponse({ error: 'Work ID is required' }, 400);
+  }
+
+  const work = await getWorkById(id, env);
+  if (!work) {
+    return jsonResponse({ error: 'Work not found' }, 404);
+  }
+
+  return jsonResponse(toWorkResource(work));
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,6 +48,11 @@ const booksWithStats = currentlyReadingBooks.map((book) => {
       </p>
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
+        <a href="/works" class="card hover:shadow-lg transition-shadow">
+          <h3>Catalog</h3>
+          <p>Find and create Works</p>
+        </a>
+
         <a href="/books" class="card hover:shadow-lg transition-shadow">
           <h3>My Library</h3>
           <p>Manage your book collection</p>

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -1,0 +1,55 @@
+---
+import { env } from 'cloudflare:workers';
+import Layout from '../../layouts/Layout.astro';
+import { getWorkById, toWorkResource } from '../../lib/catalog';
+
+const { id } = Astro.params;
+const work = id ? await getWorkById(id, env) : undefined;
+
+if (!work) {
+  Astro.response.status = 404;
+}
+
+const resource = work ? toWorkResource(work) : null;
+---
+
+<Layout title={resource ? `${resource.title} | PageTurn` : 'Work not found | PageTurn'}>
+  {
+    resource ? (
+      <div>
+        <p class="mb-4">
+          <a href="/works">Back to catalog</a>
+        </p>
+        <h1>{resource.title}</h1>
+        <dl class="card max-w-2xl space-y-4">
+          <div>
+            <dt class="text-sm text-slate-400">Title</dt>
+            <dd data-field="title" class="text-lg">
+              {resource.title}
+            </dd>
+          </div>
+          <div>
+            <dt class="text-sm text-slate-400">First publication date</dt>
+            <dd data-field="first-publication-date">
+              {resource.firstPublicationDate ?? 'Unknown'}
+            </dd>
+          </div>
+        </dl>
+        <section class="mt-8">
+          <h2>Editions</h2>
+          <p data-field="editions-empty" class="text-slate-400">
+            This Work has no Editions yet.
+          </p>
+        </section>
+      </div>
+    ) : (
+      <div class="card text-center py-12">
+        <h1>Work not found</h1>
+        <p class="mb-6">That Work is not in the local catalog.</p>
+        <a href="/works" class="btn">
+          Back to catalog
+        </a>
+      </div>
+    )
+  }
+</Layout>

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -1,7 +1,8 @@
 ---
 import { env } from 'cloudflare:workers';
 import Layout from '../../layouts/Layout.astro';
-import { getWorkById, toWorkResource } from '../../lib/catalog';
+import { toWorkResource } from '../../lib/catalog';
+import { getWorkById } from '../../lib/db';
 
 const { id } = Astro.params;
 const work = id ? await getWorkById(id, env) : undefined;

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -1,0 +1,76 @@
+---
+import { env } from 'cloudflare:workers';
+import Layout from '../../layouts/Layout.astro';
+import { searchWorks, toWorkResource } from '../../lib/catalog';
+
+const query = Astro.url.searchParams.get('q') ?? '';
+const works = (await searchWorks(query, env)).map(toWorkResource);
+---
+
+<Layout title="Catalog | PageTurn">
+  <div>
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="mb-0">Catalog</h1>
+      <a href="/works/new" class="btn">Create Work</a>
+    </div>
+
+    <p class="text-slate-300 mb-6">
+      Search locally stored Works. A Work is the intellectual creation shared by
+      its Editions, and it can exist with only a title.
+    </p>
+
+    <form method="GET" action="/works" class="mb-8 max-w-xl">
+      <label for="q" class="form-label">Search Works</label>
+      <div class="flex gap-3">
+        <input
+          type="search"
+          id="q"
+          name="q"
+          value={query}
+          placeholder="Search by title"
+          class="form-input"
+        />
+        <button type="submit" class="btn">Search</button>
+      </div>
+    </form>
+
+    {
+      works.length === 0 ? (
+        <div class="card text-center py-12">
+          <h2>No Works found</h2>
+          <p class="mb-6">
+            {query
+              ? 'No locally stored Works match that title.'
+              : 'The catalog is empty. Create a Work from a title to get started.'}
+          </p>
+          <a href="/works/new" class="btn">
+            Create Work
+          </a>
+        </div>
+      ) : (
+        <div class="overflow-x-auto">
+          <table class="w-full whitespace-nowrap">
+            <thead>
+              <tr class="bg-gray-100 dark:bg-slate-700">
+                <th class="px-4 py-3 text-left">Title</th>
+                <th class="px-4 py-3 text-left">First publication date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {works.map((work) => (
+                <tr class="border-b border-slate-700 hover:bg-slate-800/50">
+                  <td class="px-4 py-3">
+                    <a href={`/works/${work.id}`}>{work.title}</a>
+                  </td>
+                  <td class="px-4 py-3 text-slate-400">
+                    {work.firstPublicationDate ?? 'Unknown'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )
+    }
+  </div>
+</Layout>

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -1,7 +1,8 @@
 ---
 import { env } from 'cloudflare:workers';
 import Layout from '../../layouts/Layout.astro';
-import { searchWorks, toWorkResource } from '../../lib/catalog';
+import { toWorkResource } from '../../lib/catalog';
+import { searchWorks } from '../../lib/db';
 
 const query = Astro.url.searchParams.get('q') ?? '';
 const works = (await searchWorks(query, env)).map(toWorkResource);

--- a/src/pages/works/new.astro
+++ b/src/pages/works/new.astro
@@ -1,0 +1,93 @@
+---
+import { env } from 'cloudflare:workers';
+import Layout from '../../layouts/Layout.astro';
+import { CatalogValidationError, createWork } from '../../lib/catalog';
+
+let errorMessage = '';
+let formData = {
+  title: '',
+  firstPublicationDate: '',
+};
+
+if (Astro.request.method === 'POST') {
+  try {
+    const data = await Astro.request.formData();
+    formData = {
+      title: (data.get('title') as string) || '',
+      firstPublicationDate: (data.get('firstPublicationDate') as string) || '',
+    };
+
+    const { id } = await createWork(
+      {
+        title: formData.title,
+        firstPublicationDate: formData.firstPublicationDate,
+      },
+      env
+    );
+    return Astro.redirect(`/works/${id}`);
+  } catch (error) {
+    if (error instanceof CatalogValidationError) {
+      errorMessage = error.message;
+    } else {
+      console.error('Error creating Work:', error);
+      errorMessage = 'Failed to create Work. Please try again.';
+    }
+  }
+}
+---
+
+<Layout title="Create Work | PageTurn">
+  <div>
+    <h1>Create Work</h1>
+    <p class="text-slate-300 mb-6 max-w-2xl">
+      A Work needs only a title. Optional catalog facts such as first
+      publication date stay unknown until they are known — PageTurn will not
+      invent them.
+    </p>
+
+    {
+      errorMessage && (
+        <div
+          class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+          role="alert"
+        >
+          <p>{errorMessage}</p>
+        </div>
+      )
+    }
+
+    <form method="POST" class="max-w-xl mt-6 space-y-6">
+      <div>
+        <label for="title" class="form-label">Title</label>
+        <input
+          type="text"
+          id="title"
+          name="title"
+          required
+          class="form-input"
+          value={formData.title}
+        />
+      </div>
+
+      <div>
+        <label for="firstPublicationDate" class="form-label">
+          First publication date
+          <span class="text-slate-400 font-normal"> (optional)</span>
+        </label>
+        <input
+          type="date"
+          id="firstPublicationDate"
+          name="firstPublicationDate"
+          class="form-input"
+          value={formData.firstPublicationDate}
+        />
+        <p class="mt-2 text-sm text-slate-400">Leave blank if unknown.</p>
+      </div>
+
+      <div class="flex justify-end space-x-4 pt-4">
+        <a href="/works" class="btn-secondary">Cancel</a>
+        <button type="submit" class="btn">Create Work</button>
+      </div>
+    </form>
+  </div>
+</Layout>

--- a/tests/acceptance/helpers.ts
+++ b/tests/acceptance/helpers.ts
@@ -27,6 +27,8 @@ export interface RequestOptions {
   method?: string;
   cookie?: string;
   body?: unknown;
+  /** When set, sent as application/x-www-form-urlencoded instead of JSON. */
+  form?: URLSearchParams;
 }
 
 /**
@@ -41,13 +43,18 @@ export async function request(
   if (options.cookie) {
     headers.Cookie = options.cookie;
   }
-  if (options.body !== undefined) {
+  let body: string | undefined;
+  if (options.form) {
+    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    body = options.form.toString();
+  } else if (options.body !== undefined) {
     headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(options.body);
   }
   return fetch(`${baseURL}${pathname}`, {
     method: options.method ?? 'GET',
     headers,
-    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    body,
     redirect: 'manual',
   });
 }

--- a/tests/acceptance/sparse-works.test.ts
+++ b/tests/acceptance/sparse-works.test.ts
@@ -209,6 +209,27 @@ describe('sparse Works', () => {
     expect(found.works.map((item) => item.id)).toContain(work.id);
   });
 
+  it('finds a Greek title when the query uses a non-final sigma', async () => {
+    const greekTitle = `ΟΣ ${crypto.randomUUID()}`;
+    const createdGreek = await request('/api/works', {
+      method: 'POST',
+      cookie: reader.cookie,
+      body: { title: greekTitle },
+    });
+    expect(createdGreek.status).toBe(201);
+    const work = (await createdGreek.json()) as WorkResource;
+
+    for (const query of ['Σ', 'ος']) {
+      const search = await request(
+        `/api/works?q=${encodeURIComponent(query)}`,
+        { cookie: otherReader.cookie }
+      );
+      expect(search.status).toBe(200);
+      const found = (await search.json()) as WorkListResponse;
+      expect(found.works.map((item) => item.id)).toContain(work.id);
+    }
+  });
+
   it('returns at most 50 Works for an empty catalog query', async () => {
     const prefix = `Bound ${crypto.randomUUID()}`;
     const createdBatch = await Promise.all(

--- a/tests/acceptance/sparse-works.test.ts
+++ b/tests/acceptance/sparse-works.test.ts
@@ -151,6 +151,45 @@ describe('sparse Works', () => {
     expect(html).not.toContain(otherTitle);
   });
 
+  it('matches a title substring without treating LIKE wildcards as patterns', async () => {
+    const token = `Inner${crypto.randomUUID().replaceAll('-', '')}`;
+    const substringTitle = `Prefix ${token} Suffix`;
+    const createdSubstring = await request('/api/works', {
+      method: 'POST',
+      cookie: reader.cookie,
+      body: { title: substringTitle },
+    });
+    expect(createdSubstring.status).toBe(201);
+    const work = (await createdSubstring.json()) as WorkResource;
+
+    const substringSearch = await request(
+      `/api/works?q=${encodeURIComponent(token.toLowerCase())}`,
+      { cookie: otherReader.cookie }
+    );
+    expect(substringSearch.status).toBe(200);
+    const substringFound = (await substringSearch.json()) as WorkListResponse;
+    expect(substringFound.works.map((item) => item.id)).toContain(work.id);
+
+    const percentTitle = `Percent ${crypto.randomUUID()} 100%`;
+    const createdPercent = await request('/api/works', {
+      method: 'POST',
+      cookie: reader.cookie,
+      body: { title: percentTitle },
+    });
+    expect(createdPercent.status).toBe(201);
+    const percentWork = (await createdPercent.json()) as WorkResource;
+
+    const wildcardSearch = await request(
+      `/api/works?q=${encodeURIComponent('%')}`,
+      { cookie: otherReader.cookie }
+    );
+    expect(wildcardSearch.status).toBe(200);
+    const wildcardFound = (await wildcardSearch.json()) as WorkListResponse;
+    expect(wildcardFound.works.map((item) => item.id)).toContain(percentWork.id);
+    expect(wildcardFound.works.map((item) => item.id)).not.toContain(work.id);
+    expect(wildcardFound.works.map((item) => item.id)).not.toContain(created.id);
+  });
+
   it('finds Works whose titles use non-ASCII letters regardless of query case', async () => {
     const unicodeTitle = `Éclair ${crypto.randomUUID()}`;
     const createdUnicode = await request('/api/works', {
@@ -168,6 +207,26 @@ describe('sparse Works', () => {
     expect(search.status).toBe(200);
     const found = (await search.json()) as WorkListResponse;
     expect(found.works.map((item) => item.id)).toContain(work.id);
+  });
+
+  it('returns at most 50 Works for an empty catalog query', async () => {
+    const prefix = `Bound ${crypto.randomUUID()}`;
+    const createdBatch = await Promise.all(
+      Array.from({ length: 51 }, (_, index) =>
+        request('/api/works', {
+          method: 'POST',
+          cookie: reader.cookie,
+          body: { title: `${prefix} ${String(index).padStart(2, '0')}` },
+        })
+      )
+    );
+    expect(createdBatch.every((response) => response.status === 201)).toBe(true);
+
+    const list = await request('/api/works', { cookie: reader.cookie });
+    expect(list.status).toBe(200);
+    const found = (await list.json()) as WorkListResponse;
+    expect(found.works).toHaveLength(50);
+    expect(found).toEqual({ works: found.works });
   });
 
   it('creates a Work from the catalog form without requiring other facts', async () => {

--- a/tests/acceptance/sparse-works.test.ts
+++ b/tests/acceptance/sparse-works.test.ts
@@ -1,0 +1,175 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  deleteFixtures,
+  request,
+  signUpFixture,
+  type Fixture,
+} from './helpers';
+
+interface WorkResource {
+  id: string;
+  title: string;
+  firstPublicationDate: string | null;
+}
+
+interface WorkListResponse {
+  works: WorkResource[];
+}
+
+interface BookResponse {
+  id: string;
+  title: string;
+}
+
+describe('sparse Works', () => {
+  let reader: Fixture;
+  let otherReader: Fixture;
+  const title = `Obscure Tract ${crypto.randomUUID()}`;
+  const otherTitle = `Unrelated Work ${crypto.randomUUID()}`;
+  let created: WorkResource;
+
+  beforeAll(async () => {
+    reader = await signUpFixture('works-reader');
+    otherReader = await signUpFixture('works-other');
+  });
+
+  afterAll(() => {
+    deleteFixtures([reader, otherReader]);
+  });
+
+  it('rejects catalog mutation without a session', async () => {
+    const response = await request('/api/works', {
+      method: 'POST',
+      body: { title },
+    });
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('redirects the catalog pages without a session', async () => {
+    for (const path of ['/works', '/works/new']) {
+      const response = await request(path);
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe('/login');
+    }
+  });
+
+  it('rejects a Work without a title', async () => {
+    const response = await request('/api/works', {
+      method: 'POST',
+      cookie: reader.cookie,
+      body: { title: '   ' },
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Title is required' });
+  });
+
+  it('lets an authenticated Reader create a Work from only a title', async () => {
+    const response = await request('/api/works', {
+      method: 'POST',
+      cookie: reader.cookie,
+      body: {
+        title,
+        author: 'Fabricated Author',
+        format: 'Paperback',
+        pageCount: 0,
+        publishedYear: 0,
+        genre: 'Unknown',
+      },
+    });
+    expect(response.status).toBe(201);
+    created = (await response.json()) as WorkResource;
+    expect(created.id).toBeTruthy();
+    expect(created.title).toBe(title);
+    expect(created.firstPublicationDate).toBeNull();
+    expect(created).toEqual({
+      id: created.id,
+      title,
+      firstPublicationDate: null,
+    });
+  });
+
+  it('does not create an Edition, Library Entry, Holding Period, or Reading Attempt', async () => {
+    const [library, sessions, detail] = await Promise.all([
+      request('/api/books', { cookie: reader.cookie }),
+      request('/api/reading-sessions', { cookie: reader.cookie }),
+      request(`/api/works/${created.id}`, { cookie: reader.cookie }),
+    ]);
+    expect(library.status).toBe(200);
+    const books = (await library.json()) as BookResponse[];
+    expect(books.map((book) => book.title)).not.toContain(title);
+
+    expect(sessions.status).toBe(200);
+    expect(await sessions.json()).toEqual([]);
+
+    expect(detail.status).toBe(200);
+    expect(await detail.json()).toEqual({
+      id: created.id,
+      title,
+      firstPublicationDate: null,
+    });
+  });
+
+  it('keeps unknown optional catalog facts unknown on the Work detail view', async () => {
+    const response = await request(`/works/${created.id}`, {
+      cookie: reader.cookie,
+    });
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain(title);
+    expect(html).toMatch(
+      /data-field="first-publication-date"[^>]*>\s*Unknown\s*</
+    );
+    expect(html).toContain('This Work has no Editions yet.');
+    expect(html).not.toContain('Fabricated Author');
+  });
+
+  it('lets Readers search locally stored Works and open the stable detail view', async () => {
+    const other = await request('/api/works', {
+      method: 'POST',
+      cookie: otherReader.cookie,
+      body: { title: otherTitle },
+    });
+    expect(other.status).toBe(201);
+
+    const search = await request(`/api/works?q=${encodeURIComponent(title)}`, {
+      cookie: otherReader.cookie,
+    });
+    expect(search.status).toBe(200);
+    const found = (await search.json()) as WorkListResponse;
+    expect(found.works.map((work) => work.id)).toContain(created.id);
+    expect(found.works.map((work) => work.title)).not.toContain(otherTitle);
+
+    const catalogPage = await request(
+      `/works?q=${encodeURIComponent(title)}`,
+      { cookie: reader.cookie }
+    );
+    expect(catalogPage.status).toBe(200);
+    const html = await catalogPage.text();
+    expect(html).toContain(title);
+    expect(html).toContain(`/works/${created.id}`);
+    expect(html).not.toContain(otherTitle);
+  });
+
+  it('creates a Work from the catalog form without requiring other facts', async () => {
+    const formTitle = `Form Tract ${crypto.randomUUID()}`;
+    const response = await request('/works/new', {
+      method: 'POST',
+      cookie: reader.cookie,
+      form: new URLSearchParams({ title: formTitle }),
+    });
+    expect(response.status).toBe(302);
+    const location = response.headers.get('location');
+    expect(location).toBeTruthy();
+    const detailPath = new URL(location!, 'http://acceptance.invalid').pathname;
+    expect(detailPath).toMatch(/^\/works\/[0-9a-f-]{36}$/i);
+
+    const detail = await request(detailPath, { cookie: reader.cookie });
+    expect(detail.status).toBe(200);
+    const html = await detail.text();
+    expect(html).toContain(formTitle);
+    expect(html).toMatch(
+      /data-field="first-publication-date"[^>]*>\s*Unknown\s*</
+    );
+  });
+});

--- a/tests/acceptance/sparse-works.test.ts
+++ b/tests/acceptance/sparse-works.test.ts
@@ -151,6 +151,25 @@ describe('sparse Works', () => {
     expect(html).not.toContain(otherTitle);
   });
 
+  it('finds Works whose titles use non-ASCII letters regardless of query case', async () => {
+    const unicodeTitle = `Éclair ${crypto.randomUUID()}`;
+    const createdUnicode = await request('/api/works', {
+      method: 'POST',
+      cookie: reader.cookie,
+      body: { title: unicodeTitle },
+    });
+    expect(createdUnicode.status).toBe(201);
+    const work = (await createdUnicode.json()) as WorkResource;
+
+    const search = await request(
+      `/api/works?q=${encodeURIComponent(unicodeTitle.toLowerCase())}`,
+      { cookie: otherReader.cookie }
+    );
+    expect(search.status).toBe(200);
+    const found = (await search.json()) as WorkListResponse;
+    expect(found.works.map((item) => item.id)).toContain(work.id);
+  });
+
   it('creates a Work from the catalog form without requiring other facts', async () => {
     const formTitle = `Form Tract ${crypto.randomUUID()}`;
     const response = await request('/works/new', {

--- a/tests/migrations/reader-deletion.test.ts
+++ b/tests/migrations/reader-deletion.test.ts
@@ -144,6 +144,61 @@ describe('the user_id cascade rebuild (0006)', () => {
   });
 });
 
+describe('works title_search (0008)', () => {
+  const SEARCH_TAG = '0008_known_lila_cheney';
+
+  function insertWork(db: DatabaseSync, id: string, title: string): void {
+    db.prepare(
+      `INSERT INTO works (id, title, first_publication_date) VALUES (?, ?, NULL)`
+    ).run(id, title);
+  }
+
+  it('backfills a searchable title and indexes it without dropping existing Works', () => {
+    const db = openScratchDatabase();
+    try {
+      const tags = migrationTags();
+      const searchIndex = tags.indexOf(SEARCH_TAG);
+      expect(searchIndex).toBeGreaterThan(0);
+      for (const tag of tags.slice(0, searchIndex)) {
+        applyMigration(db, tag);
+      }
+
+      insertWork(db, 'work-ascii', 'Hello World');
+      insertWork(db, 'work-kept', 'Kept Title');
+
+      applyMigration(db, SEARCH_TAG);
+
+      const rows = db
+        .prepare('SELECT id, title, title_search FROM works ORDER BY id')
+        .all() as { id: string; title: string; title_search: string }[];
+      expect(rows).toEqual([
+        { id: 'work-ascii', title: 'Hello World', title_search: 'hello world' },
+        { id: 'work-kept', title: 'Kept Title', title_search: 'kept title' },
+      ]);
+
+      const indexes = db
+        .prepare(
+          `SELECT name FROM sqlite_master
+           WHERE type = 'index' AND tbl_name = 'works'
+           AND name NOT LIKE 'sqlite_%' ORDER BY name`
+        )
+        .all()
+        .map((row) => (row as { name: string }).name);
+      expect(indexes).toEqual(['works_title_idx', 'works_title_search_idx']);
+
+      db.prepare(
+        `INSERT INTO works (id, title, title_search, first_publication_date)
+         VALUES ('work-new', 'New Title', 'new title', NULL)`
+      ).run();
+      expect(
+        db.prepare('SELECT title_search FROM works WHERE id = ?').get('work-new')
+      ).toEqual({ title_search: 'new title' });
+    } finally {
+      db.close();
+    }
+  });
+});
+
 describe('Reader deletion', () => {
   it('cascades to the `books` and `reading_sessions` rows the Reader owns', () => {
     const db = openMigratedDatabase();

--- a/tests/migrations/reader-deletion.test.ts
+++ b/tests/migrations/reader-deletion.test.ts
@@ -165,6 +165,8 @@ describe('works title_search (0008)', () => {
 
       insertWork(db, 'work-ascii', 'Hello World');
       insertWork(db, 'work-kept', 'Kept Title');
+      // SQLite lower() folds ASCII only. D1 SQL cannot NFC-normalize.
+      insertWork(db, 'work-accent', 'Éclair');
 
       applyMigration(db, SEARCH_TAG);
 
@@ -172,6 +174,7 @@ describe('works title_search (0008)', () => {
         .prepare('SELECT id, title, title_search FROM works ORDER BY id')
         .all() as { id: string; title: string; title_search: string }[];
       expect(rows).toEqual([
+        { id: 'work-accent', title: 'Éclair', title_search: 'Éclair' },
         { id: 'work-ascii', title: 'Hello World', title_search: 'hello world' },
         { id: 'work-kept', title: 'Kept Title', title_search: 'kept title' },
       ]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #254.

Authenticated Readers can grow the shared catalog with a sparse Work: title is required, optional facts such as first publication date stay unknown, and creation does not invent an Edition, Library Entry, Holding Period, or Reading Attempt.

## What changed

- Added a `works` table (title plus optional first publication date) and catalog helpers.
- `POST /api/works` creates a Work; `GET /api/works?q=` searches locally stored Works; `GET /api/works/:id` and `/works/:id` are the stable detail view.
- Catalog UI at `/works` and `/works/new` for search and manual creation.
- Unauthenticated catalog mutation still returns `{ error: "Unauthorized" }` (401). Shared Works are visible to other authenticated Readers.
- Acceptance coverage for creation, sparse display, local search, form create, and the auth boundary.
- Stopped importing the unused better-sqlite3 driver in the D1 client so the first Catalog page load does not stall in CI.

## Notes

Edition, Subject, and Contributor records are intentionally out of scope here and remain follow-on work (#255, #259, #258).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c4b67a4-53a1-4666-9463-e0d2cb93751d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c4b67a4-53a1-4666-9463-e0d2cb93751d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

